### PR TITLE
Add AggregationExceptions. Implements #10

### DIFF
--- a/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
+++ b/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
@@ -48,6 +48,7 @@ import org.dmfs.android.calendarpal.tables.CalendarScoped;
 import org.dmfs.android.calendarpal.tables.Calendars;
 import org.dmfs.android.calendarpal.tables.Events;
 import org.dmfs.android.calendarpal.tables.Reminders;
+import org.dmfs.android.contactspal.aggregation.Link;
 import org.dmfs.android.contactspal.batches.InsertRawContactBatch;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Primary;
@@ -80,6 +81,7 @@ import org.dmfs.android.contentpal.OperationsQueue;
 import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.batches.Joined;
 import org.dmfs.android.contentpal.batches.MultiBatch;
 import org.dmfs.android.contentpal.batches.MultiInsertBatch;
 import org.dmfs.android.contentpal.batches.SingletonBatch;
@@ -202,6 +204,22 @@ public class DemoActivity extends AppCompatActivity
                                         new CityData("Dresden"),
                                         new CountryData("Germany")))));
         mContactsQueue.flush();
+
+        // create another "virtual" row snapshot of a RawContact row
+        RowSnapshot<ContactsContract.RawContacts> rawContact2 = new VirtualRowSnapshot<>(mRawContacts);
+
+        // insert the contact and link it to the first one in the same transaction
+        mContactsQueue.enqueue(
+                new Joined(
+                        new InsertRawContactBatch(rawContact2,
+                                new DisplayNameData("Donald Duck"),
+                                new Typed(ContactsContract.CommonDataKinds.Phone.TYPE_WORK, new PhoneData("9876"))
+                        ),
+                        // Demonstrate how to link two contacts
+                        new SingletonBatch(new Link(rawContact, rawContact2)))
+        );
+        mContactsQueue.flush();
+
     }
 
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationException.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationException.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.aggregation;
+
+import android.content.ContentProviderOperation;
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contactspal.tables.AggregationExceptions;
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.RowReference;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.android.contentpal.predicates.AnyOf;
+import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
+import org.dmfs.optional.Absent;
+import org.dmfs.optional.Optional;
+
+
+/**
+ * An {@link Operation} which updates the aggregation exception of two specific raw contacts.
+ *
+ * @author Marten Gajda
+ */
+final class AggregationException implements Operation<ContactsContract.AggregationExceptions>
+{
+    private final RowReference<ContactsContract.RawContacts> mRawContact1;
+    private final RowReference<ContactsContract.RawContacts> mRawContact2;
+
+
+    AggregationException(@NonNull RowReference<ContactsContract.RawContacts> rawContact1, @NonNull RowReference<ContactsContract.RawContacts> rawContact2)
+    {
+        mRawContact1 = rawContact1;
+        mRawContact2 = rawContact2;
+    }
+
+
+    @NonNull
+    @Override
+    public Optional<SoftRowReference<ContactsContract.AggregationExceptions>> reference()
+    {
+        // you can't refer to a specific row in the aggregation table
+        return Absent.absent();
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
+    {
+        // updating Aggregation exceptions works a bit strange. Instead of selecting a specific entry, we have to refer to them in the values.
+        return mRawContact2.builderWithReferenceData(
+                transactionContext,
+                mRawContact1.builderWithReferenceData(
+                        transactionContext,
+                        AggregationExceptions.INSTANCE.updateOperation(
+                                EmptyUriParams.INSTANCE,
+                                new AnyOf()
+                        ).contentOperationBuilder(transactionContext),
+                        ContactsContract.AggregationExceptions.RAW_CONTACT_ID1), ContactsContract.AggregationExceptions.RAW_CONTACT_ID2);
+
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationTypeData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationTypeData.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.aggregation;
+
+import android.content.ContentProviderOperation;
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.RowData;
+
+
+/**
+ * The {@link RowData} of the {@link ContactsContract.AggregationExceptions} table.
+ *
+ * @author Marten Gajda
+ */
+final class AggregationTypeData implements RowData<ContactsContract.AggregationExceptions>
+{
+    private final int mType;
+
+
+    AggregationTypeData(int type)
+    {
+        mType = type;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    {
+        return builder.withValue(ContactsContract.AggregationExceptions.TYPE, mType);
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AutoAggregate.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AutoAggregate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.aggregation;
+
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.RowReference;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.operations.DelegatingOperation;
+import org.dmfs.android.contentpal.operations.Populated;
+import org.dmfs.android.contentpal.references.RowSnapshotReference;
+
+
+/**
+ * An {@link Operation} which let's Android decide whether two raw contacts should be aggregated.
+ *
+ * @author Marten Gajda
+ */
+public final class AutoAggregate extends DelegatingOperation<ContactsContract.AggregationExceptions>
+{
+
+    public AutoAggregate(@NonNull RowSnapshot<ContactsContract.RawContacts> rawContact1, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact2)
+    {
+        this(new RowSnapshotReference<>(rawContact1), new RowSnapshotReference<>(rawContact2));
+    }
+
+
+    public AutoAggregate(@NonNull RowReference<ContactsContract.RawContacts> rawContact1, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact2)
+    {
+        this(rawContact1, new RowSnapshotReference<>(rawContact2));
+    }
+
+
+    public AutoAggregate(@NonNull RowReference<ContactsContract.RawContacts> rawContact1, @NonNull RowReference<ContactsContract.RawContacts> rawContact2)
+    {
+        super(new Populated<>(
+                new AggregationTypeData(ContactsContract.AggregationExceptions.TYPE_AUTOMATIC),
+                new AggregationException(rawContact1, rawContact2)));
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/Link.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/Link.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.aggregation;
+
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.RowReference;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.operations.DelegatingOperation;
+import org.dmfs.android.contentpal.operations.Populated;
+import org.dmfs.android.contentpal.references.RowSnapshotReference;
+
+
+/**
+ * An {@link Operation} which links two raw contacts;
+ *
+ * @author Marten Gajda
+ */
+public final class Link extends DelegatingOperation<ContactsContract.AggregationExceptions>
+{
+    public Link(@NonNull RowSnapshot<ContactsContract.RawContacts> rawContact1, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact2)
+    {
+        this(new RowSnapshotReference<>(rawContact1), new RowSnapshotReference<>(rawContact2));
+    }
+
+
+    public Link(@NonNull RowReference<ContactsContract.RawContacts> rawContact1, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact2)
+    {
+        this(rawContact1, new RowSnapshotReference<>(rawContact2));
+    }
+
+
+    public Link(@NonNull RowReference<ContactsContract.RawContacts> rawContact1, @NonNull RowReference<ContactsContract.RawContacts> rawContact2)
+    {
+        super(new Populated<>(
+                new AggregationTypeData(ContactsContract.AggregationExceptions.TYPE_KEEP_TOGETHER),
+                new AggregationException(rawContact1, rawContact2)));
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/Split.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/Split.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.aggregation;
+
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.RowReference;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.operations.DelegatingOperation;
+import org.dmfs.android.contentpal.operations.Populated;
+import org.dmfs.android.contentpal.references.RowSnapshotReference;
+
+
+/**
+ * An {@link Operation} which separates two raw contacts.
+ *
+ * @author Marten Gajda
+ */
+public final class Split extends DelegatingOperation<ContactsContract.AggregationExceptions>
+{
+
+    public Split(@NonNull RowSnapshot<ContactsContract.RawContacts> rawContact1, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact2)
+    {
+        this(new RowSnapshotReference<>(rawContact1), new RowSnapshotReference<>(rawContact2));
+    }
+
+
+    public Split(@NonNull RowReference<ContactsContract.RawContacts> rawContact1, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact2)
+    {
+        this(rawContact1, new RowSnapshotReference<>(rawContact2));
+    }
+
+
+    public Split(@NonNull RowReference<ContactsContract.RawContacts> rawContact1, @NonNull RowReference<ContactsContract.RawContacts> rawContact2)
+    {
+        super(new Populated<>(
+                new AggregationTypeData(ContactsContract.AggregationExceptions.TYPE_KEEP_SEPARATE),
+                new AggregationException(rawContact1, rawContact2)));
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkLinkBatch.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkLinkBatch.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.batches;
+
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contactspal.aggregation.Link;
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.OperationsBatch;
+import org.dmfs.android.contentpal.RowReference;
+import org.dmfs.iterators.Function;
+import org.dmfs.iterators.decorators.Mapped;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link OperationsBatch} which links a given RawContact to number of other {@link ContactsContract.RawContacts}.
+ *
+ * @author Marten Gajda
+ */
+public final class BulkLinkBatch implements OperationsBatch
+{
+    private final RowReference<ContactsContract.RawContacts> mRawContact;
+    private final Iterable<RowReference<ContactsContract.RawContacts>> mLinked;
+
+
+    public BulkLinkBatch(@NonNull RowReference<ContactsContract.RawContacts> rawContact, @NonNull Iterable<RowReference<ContactsContract.RawContacts>> linked)
+    {
+        mRawContact = rawContact;
+        mLinked = linked;
+    }
+
+
+    @Override
+    public Iterator<Operation<?>> iterator()
+    {
+        return new Mapped<>(mLinked.iterator(), new Function<RowReference<ContactsContract.RawContacts>, Operation<?>>()
+        {
+
+            @Override
+            public Operation<?> apply(RowReference<ContactsContract.RawContacts> rawContactsRowReference)
+            {
+                return new Link(mRawContact, rawContactsRowReference);
+            }
+        });
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkSplitBatch.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkSplitBatch.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.batches;
+
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contactspal.aggregation.Split;
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.OperationsBatch;
+import org.dmfs.android.contentpal.RowReference;
+import org.dmfs.iterators.Function;
+import org.dmfs.iterators.decorators.Mapped;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link OperationsBatch} which splits a given RawContact from a number of other {@link ContactsContract.RawContacts}.
+ *
+ * @author Marten Gajda
+ */
+public final class BulkSplitBatch implements OperationsBatch
+{
+    private final RowReference<ContactsContract.RawContacts> mRawContact;
+    private final Iterable<RowReference<ContactsContract.RawContacts>> mLinked;
+
+
+    public BulkSplitBatch(@NonNull RowReference<ContactsContract.RawContacts> rawContact, @NonNull Iterable<RowReference<ContactsContract.RawContacts>> linked)
+    {
+        mRawContact = rawContact;
+        mLinked = linked;
+    }
+
+
+    @Override
+    public Iterator<Operation<?>> iterator()
+    {
+        return new Mapped<>(mLinked.iterator(), new Function<RowReference<ContactsContract.RawContacts>, Operation<?>>()
+        {
+
+            @Override
+            public Operation<?> apply(RowReference<ContactsContract.RawContacts> rawContactsRowReference)
+            {
+                return new Split(mRawContact, rawContactsRowReference);
+            }
+        });
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/membership/GroupRowMembership.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/membership/GroupRowMembership.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 
 
 /**
@@ -43,6 +44,10 @@ public final class GroupRowMembership implements RowData<ContactsContract.Data>
     public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
     {
         // this data row refers to the given group
-        return mGroup.reference().builderWithReferenceData(builder, ContactsContract.CommonDataKinds.GroupMembership.GROUP_ROW_ID);
+        return mGroup.reference()
+                // TODO: we don't have access to the transaction context, which means the group has to exists already.
+                // One solution could be to pass the TransactionContext to updateBuilder, so rowData objects can resolve virtual row snapshots
+                // see: https://github.com/dmfs/ContentPal/issues/27
+                .builderWithReferenceData(EmptyTransactionContext.INSTANCE, builder, ContactsContract.CommonDataKinds.GroupMembership.GROUP_ROW_ID);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.tables;
+
+import android.content.ContentProviderClient;
+import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.InsertOperation;
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.UriParams;
+import org.dmfs.android.contentpal.View;
+import org.dmfs.android.contentpal.tables.BaseTable;
+
+
+/**
+ * The ContactsProvider {@link ContactsContract.AggregationExceptions} {@link Table}. Note that this table supports neither insert nor delete operations.
+ *
+ * @author Marten Gajda
+ */
+public final class AggregationExceptions implements Table<ContactsContract.AggregationExceptions>
+{
+    public final static AggregationExceptions INSTANCE = new AggregationExceptions();
+
+    private final Table<ContactsContract.AggregationExceptions> mDelegate;
+
+
+    public AggregationExceptions()
+    {
+        mDelegate = new BaseTable<>(ContactsContract.AggregationExceptions.CONTENT_URI);
+    }
+
+
+    @NonNull
+    @Override
+    public InsertOperation<ContactsContract.AggregationExceptions> insertOperation(@NonNull UriParams uriParams)
+    {
+        throw new UnsupportedOperationException("AggregationExceptions doesn't support inserts");
+    }
+
+
+    @NonNull
+    @Override
+    public Operation<ContactsContract.AggregationExceptions> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return mDelegate.updateOperation(uriParams, predicate);
+    }
+
+
+    @NonNull
+    @Override
+    public Operation<ContactsContract.AggregationExceptions> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        throw new UnsupportedOperationException("AggregationExceptions doesn't support deletes");
+    }
+
+
+    @NonNull
+    @Override
+    public View<ContactsContract.AggregationExceptions> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    {
+        return mDelegate.view(client, projection);
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/RowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/RowReference.java
@@ -60,12 +60,14 @@ public interface RowReference<T>
     /**
      * Select the referred item in the given {@link ContentProviderOperation.Builder}.
      *
+     * @param transactionContext
+     *         A {@link TransactionContext} of the {@link Transaction} this is being executed in.
      * @param operationBuilder
      *         The  {@link ContentProviderOperation.Builder}.
      * @param foreignKeyColumn
      */
     @NonNull
-    ContentProviderOperation.Builder builderWithReferenceData(@NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn);
+    ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn);
 
     /**
      * Returns a {@link Predicate} which matches the row on the given key column.

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/DelegatingOperation.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/DelegatingOperation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.optional.Optional;
+
+
+/**
+ * Abstract {@link Operation} which delegates all calls to another operation.
+ *
+ * @author Marten Gajda
+ */
+public abstract class DelegatingOperation<T> implements Operation<T>
+{
+    private final Operation<T> mDelegate;
+
+
+    public DelegatingOperation(@NonNull Operation<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @NonNull
+    @Override
+    public final Optional<SoftRowReference<T>> reference()
+    {
+        return mDelegate.reference();
+    }
+
+
+    @NonNull
+    @Override
+    public final ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
+    {
+        return mDelegate.contentOperationBuilder(transactionContext);
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Related.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Related.java
@@ -60,6 +60,6 @@ public final class Related<T, V> implements InsertOperation<T>
     public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
     {
         return transactionContext.resolved(mRowSnapshot.reference())
-                .builderWithReferenceData(mDelegate.contentOperationBuilder(transactionContext), mForeignKeyColumn);
+                .builderWithReferenceData(transactionContext, mDelegate.contentOperationBuilder(transactionContext), mForeignKeyColumn);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
@@ -65,7 +65,7 @@ public final class AbsoluteRowReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder builderWithReferenceData(@NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
+    public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         return operationBuilder.withValue(foreignKeyColumn, rowId());
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/BackReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/BackReference.java
@@ -69,7 +69,7 @@ public final class BackReference<T> implements RowReference<T>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder builderWithReferenceData(@NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
+    public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         return operationBuilder.withValueBackReference(foreignKeyColumn, mBackReference);
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
@@ -19,29 +19,25 @@ package org.dmfs.android.contentpal.references;
 import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
-import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.RowReference;
-import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
- * The {@link SoftRowReference} of an {@link InsertOperation}.
- * <p>
- * Note that by design {@link RowReference#putOperationBuilder(TransactionContext)} returns a {@link ContentProviderOperation.Builder} to insert a new row on
- * every call.
+ * A {@link RowReference} to a row identified by its {@link RowSnapshot}.
  *
  * @author Marten Gajda
  */
-public final class VirtualRowReference<T> implements SoftRowReference<T>
+public final class RowSnapshotReference<T> implements RowReference<T>
 {
-    private final InsertOperation<T> mInsertOperation;
+    private final RowSnapshot<T> mRowSnapshot;
 
 
-    public VirtualRowReference(@NonNull InsertOperation<T> insertOperation)
+    public RowSnapshotReference(@NonNull RowSnapshot<T> rowSnapshot)
     {
-        mInsertOperation = insertOperation;
+        mRowSnapshot = rowSnapshot;
     }
 
 
@@ -49,7 +45,7 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
     @Override
     public ContentProviderOperation.Builder putOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mInsertOperation.contentOperationBuilder(transactionContext);
+        return mRowSnapshot.reference().putOperationBuilder(transactionContext);
     }
 
 
@@ -57,7 +53,7 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
     @Override
     public ContentProviderOperation.Builder deleteOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        throw new UnsupportedOperationException("Can't delete a virtual row.");
+        return mRowSnapshot.reference().deleteOperationBuilder(transactionContext);
     }
 
 
@@ -65,7 +61,7 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
     @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
-        return transactionContext.resolved(this).builderWithReferenceData(transactionContext, operationBuilder, foreignKeyColumn);
+        return mRowSnapshot.reference().builderWithReferenceData(transactionContext, operationBuilder, foreignKeyColumn);
     }
 
 
@@ -73,13 +69,6 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
     @Override
     public Predicate predicate(@NonNull String keyColumn)
     {
-        throw new UnsupportedOperationException("Can't create a predicate which matches a virtual row.");
-    }
-
-
-    @Override
-    public boolean isVirtual()
-    {
-        return true;
+        return mRowSnapshot.reference().predicate(keyColumn);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
@@ -61,7 +61,7 @@ public final class RowUriReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder builderWithReferenceData(@NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
+    public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         return operationBuilder.withValue(foreignKeyColumn, rowId());
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/contexts/EmptyTransactionContext.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/contexts/EmptyTransactionContext.java
@@ -38,6 +38,11 @@ public final class EmptyTransactionContext implements TransactionContext
     @Override
     public <T> RowReference<T> resolved(@NonNull SoftRowReference<T> reference)
     {
+        if (reference.isVirtual())
+        {
+            // we need to throw here, otherwise we might end up in an infinite loop
+            throw new IllegalArgumentException(String.format("Unable to resolve virtual RowReference %s", reference));
+        }
         return reference;
     }
 


### PR DESCRIPTION
To use it just create a `Link`, `Split` or `AutoAggregate` operation for two specific contacts.

In addition this adds bulk operations to link or split a raw contact to/from multiple other raw contacts.

This commit also adds the TransactionContext to `RowReference.builderWithReferenceData(…)` in order to be able to add references to virtual RowSnapshots.