### PR TITLE
Add TransactionContext to RowData.updatedBuilder(…). Fixes #27

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -44,7 +44,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/AttendeeData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/AttendeeData.java
@@ -21,6 +21,7 @@ import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -65,7 +66,7 @@ public final class AttendeeData implements RowData<CalendarContract.Attendees>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder.withValue(CalendarContract.Attendees.ATTENDEE_EMAIL, mAttendeeEmail.toString())
                 .withValue(CalendarContract.Attendees.ATTENDEE_TYPE, mType)

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/Named.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/Named.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -44,8 +45,9 @@ public final class Named implements RowData<CalendarContract.Attendees>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Attendees.ATTENDEE_NAME, mName == null ? null : mName.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(CalendarContract.Attendees.ATTENDEE_NAME, mName == null ? null : mName.toString());
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/CalendarData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/CalendarData.java
@@ -21,6 +21,7 @@ import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -41,7 +42,7 @@ public final class CalendarData implements CalendarRowData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder.withValue(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, mName.toString())
                 .withValue(CalendarContract.Calendars.NAME, mName.toString());

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/Colored.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/Colored.java
@@ -20,6 +20,8 @@ import android.content.ContentProviderOperation;
 import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * {@link CalendarRowData} decorator to set a calendar color.
@@ -41,8 +43,8 @@ public final class Colored implements CalendarRowData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Calendars.CALENDAR_COLOR, mColor);
+        return mDelegate.updatedBuilder(transactionContext, builder).withValue(CalendarContract.Calendars.CALENDAR_COLOR, mColor);
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/Synced.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/Synced.java
@@ -20,6 +20,8 @@ import android.content.ContentProviderOperation;
 import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * {@link CalendarRowData} decorator to set a calendar to be synced.
@@ -47,8 +49,8 @@ public final class Synced implements CalendarRowData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Calendars.SYNC_EVENTS, mSynced ? 1 : 0);
+        return mDelegate.updatedBuilder(transactionContext, builder).withValue(CalendarContract.Calendars.SYNC_EVENTS, mSynced ? 1 : 0);
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/Visible.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/calendars/Visible.java
@@ -20,6 +20,8 @@ import android.content.ContentProviderOperation;
 import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * {@link CalendarRowData} decorator to set a calendar to be visible.
@@ -47,8 +49,8 @@ public final class Visible implements CalendarRowData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Calendars.VISIBLE, mVisible ? 1 : 0);
+        return mDelegate.updatedBuilder(transactionContext, builder).withValue(CalendarContract.Calendars.VISIBLE, mVisible ? 1 : 0);
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Clean.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Clean.java
@@ -21,6 +21,7 @@ import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
 
 
@@ -48,8 +49,8 @@ public final class Clean implements RowData<CalendarContract.Events>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Events.DIRTY, 0);
+        return mDelegate.updatedBuilder(transactionContext, builder).withValue(CalendarContract.Events.DIRTY, 0);
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Colored.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Colored.java
@@ -21,6 +21,7 @@ import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
 
 
@@ -50,8 +51,8 @@ public final class Colored implements RowData<CalendarContract.Events>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Events.EVENT_COLOR, mColor);
+        return mDelegate.updatedBuilder(transactionContext, builder).withValue(CalendarContract.Events.EVENT_COLOR, mColor);
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Described.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Described.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
 
 
@@ -51,8 +52,9 @@ public final class Described implements RowData<CalendarContract.Events>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Events.DESCRIPTION, mDescription == null ? null : mDescription.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(CalendarContract.Events.DESCRIPTION, mDescription == null ? null : mDescription.toString());
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Located.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Located.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
 
 
@@ -51,8 +52,9 @@ public final class Located implements RowData<CalendarContract.Events>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Events.EVENT_LOCATION, mLocation == null ? null : mLocation.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(CalendarContract.Events.EVENT_LOCATION, mLocation == null ? null : mLocation.toString());
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Organized.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/Organized.java
@@ -21,6 +21,7 @@ import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
 
 
@@ -50,8 +51,9 @@ public final class Organized implements RowData<CalendarContract.Events>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(CalendarContract.Events.ORGANIZER, mOrganizer == null ? null : mOrganizer.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(CalendarContract.Events.ORGANIZER, mOrganizer == null ? null : mOrganizer.toString());
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/RecurringEventData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/RecurringEventData.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.iterables.decorators.Mapped;
@@ -98,7 +99,7 @@ public final class RecurringEventData implements RowData<CalendarContract.Events
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder.withValue(CalendarContract.Events.DTSTART, mStart.getTimestamp())
                 .withValue(CalendarContract.Events.EVENT_TIMEZONE, mStart.isAllDay() ? "UTC" : mStart.getTimeZone().getID())

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/SingleEventData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/SingleEventData.java
@@ -21,6 +21,7 @@ import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.rfc5545.DateTime;
 
 
@@ -46,7 +47,7 @@ public final class SingleEventData implements RowData<CalendarContract.Events>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder.withValue(CalendarContract.Events.DTSTART, mStart.getTimestamp())
                 .withValue(CalendarContract.Events.EVENT_TIMEZONE, mStart.isAllDay() ? "UTC" : mStart.getTimeZone().getID())

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/reminders/ReminderData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/reminders/ReminderData.java
@@ -21,6 +21,7 @@ import android.provider.CalendarContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -55,7 +56,7 @@ public final class ReminderData implements RowData<CalendarContract.Reminders>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder.withValue(CalendarContract.Reminders.MINUTES, mMinutes)
                 .withValue(CalendarContract.Reminders.METHOD, mMethod);

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/Custom.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/Custom.java
@@ -30,6 +30,7 @@ import org.dmfs.android.contactspal.data.relation.RelationData;
 import org.dmfs.android.contactspal.data.sip.SipAddressData;
 import org.dmfs.android.contactspal.data.website.WebsiteData;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -63,9 +64,9 @@ public final class Custom implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 // note this is universal, because all supported data types use the same type and label column for custom labels
                 .withValue(ContactsContract.CommonDataKinds.Phone.TYPE, ContactsContract.CommonDataKinds.BaseTypes.TYPE_CUSTOM)
                 .withValue(ContactsContract.CommonDataKinds.Phone.LABEL, mLabel.toString());

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/Primary.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/Primary.java
@@ -21,6 +21,7 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -41,8 +42,8 @@ public final class Primary implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(ContactsContract.Data.IS_PRIMARY, 1);
+        return mDelegate.updatedBuilder(transactionContext, builder).withValue(ContactsContract.Data.IS_PRIMARY, 1);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/Typed.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/Typed.java
@@ -30,6 +30,7 @@ import org.dmfs.android.contactspal.data.relation.RelationData;
 import org.dmfs.android.contactspal.data.sip.SipAddressData;
 import org.dmfs.android.contactspal.data.website.WebsiteData;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -63,9 +64,9 @@ public final class Typed implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         // note that all data types use the same column for TYPE
-        return mDelegate.updatedBuilder(builder).withValue(ContactsContract.CommonDataKinds.Phone.TYPE, mType);
+        return mDelegate.updatedBuilder(transactionContext, builder).withValue(ContactsContract.CommonDataKinds.Phone.TYPE, mType);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/email/EmailData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/email/EmailData.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -45,7 +46,7 @@ public final class EmailData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Email.MIMETYPE, ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/event/EventData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/event/EventData.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -49,7 +50,7 @@ public final class EventData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Event.MIMETYPE, ContactsContract.CommonDataKinds.Event.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/im/ImData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/im/ImData.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -61,7 +62,7 @@ public final class ImData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Im.MIMETYPE, ContactsContract.CommonDataKinds.Im.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/membership/GroupRowMembership.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/membership/GroupRowMembership.java
@@ -22,7 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.RowSnapshot;
-import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -41,13 +41,10 @@ public final class GroupRowMembership implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         // this data row refers to the given group
-        return mGroup.reference()
-                // TODO: we don't have access to the transaction context, which means the group has to exists already.
-                // One solution could be to pass the TransactionContext to updateBuilder, so rowData objects can resolve virtual row snapshots
-                // see: https://github.com/dmfs/ContentPal/issues/27
-                .builderWithReferenceData(EmptyTransactionContext.INSTANCE, builder, ContactsContract.CommonDataKinds.GroupMembership.GROUP_ROW_ID);
+        return transactionContext.resolved(mGroup.reference())
+                .builderWithReferenceData(transactionContext, builder, ContactsContract.CommonDataKinds.GroupMembership.GROUP_ROW_ID);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/membership/GroupSourceMembership.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/membership/GroupSourceMembership.java
@@ -21,6 +21,7 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -39,7 +40,7 @@ public final class GroupSourceMembership implements RowData<ContactsContract.Dat
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder.withValue(ContactsContract.CommonDataKinds.GroupMembership.GROUP_SOURCE_ID, mGroupSourceId);
     }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/DisplayNameData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/DisplayNameData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * Display name of a {@link ContactsContract.CommonDataKinds.StructuredName} row.
@@ -48,9 +50,9 @@ public final class DisplayNameData implements StructuredNameData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME, mDisplayName == null ? null : mDisplayName.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/EmptyNameData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/EmptyNameData.java
@@ -20,6 +20,8 @@ import android.content.ContentProviderOperation;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * {@link StructuredNameData} which doesn't add any values. This has package scope because it's not supposed to be used by developers.
@@ -33,7 +35,7 @@ final class EmptyNameData implements StructuredNameData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         // add content item type here, so other name data can just delegate this part
         return builder.withValue(ContactsContract.CommonDataKinds.StructuredName.MIMETYPE, ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE);

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/NameData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/NameData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * Display name of a {@link ContactsContract.CommonDataKinds.StructuredName} row.
@@ -50,9 +52,9 @@ public final class NameData implements StructuredNameData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME, mFirstName == null ? null : mFirstName.toString())
                 .withValue(ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME, mLastName == null ? null : mLastName.toString());
     }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/PhoneticNameData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/PhoneticNameData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * Phonetic name component of a {@link StructuredNameData}.
@@ -52,9 +54,9 @@ public final class PhoneticNameData implements StructuredNameData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredName.PHONETIC_GIVEN_NAME, mFirstName == null ? null : mFirstName.toString())
                 .withValue(ContactsContract.CommonDataKinds.StructuredName.PHONETIC_MIDDLE_NAME, mMiddleName == null ? null : mMiddleName.toString())
                 .withValue(ContactsContract.CommonDataKinds.StructuredName.PHONETIC_FAMILY_NAME, mLastName == null ? null : mLastName.toString());

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/Prefixed.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/Prefixed.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * Decorator to add a prefix to {@link StructuredNameData}.
@@ -48,8 +50,9 @@ public final class Prefixed implements StructuredNameData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(ContactsContract.CommonDataKinds.StructuredName.PREFIX, mPrefix == null ? null : mPrefix.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(ContactsContract.CommonDataKinds.StructuredName.PREFIX, mPrefix == null ? null : mPrefix.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/Suffixed.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/name/Suffixed.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * Decorator to add a suffix to {@link StructuredNameData}.
@@ -48,8 +50,9 @@ public final class Suffixed implements StructuredNameData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(ContactsContract.CommonDataKinds.StructuredName.SUFFIX, mSuffix == null ? null : mSuffix.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(ContactsContract.CommonDataKinds.StructuredName.SUFFIX, mSuffix == null ? null : mSuffix.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/nickname/NicknameData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/nickname/NicknameData.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -45,7 +46,7 @@ public final class NicknameData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Nickname.MIMETYPE, ContactsContract.CommonDataKinds.Nickname.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/note/NoteData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/note/NoteData.java
@@ -21,6 +21,7 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -41,7 +42,7 @@ public final class NoteData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Note.MIMETYPE, ContactsContract.CommonDataKinds.Note.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/CompanyData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/CompanyData.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -53,9 +54,9 @@ public final class CompanyData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.Organization.COMPANY, mCompany == null ? null : mCompany.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/DepartmentData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/DepartmentData.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -53,9 +54,9 @@ public final class DepartmentData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.Organization.DEPARTMENT, mDepartment == null ? null : mDepartment.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/EmptyOrganizationData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/EmptyOrganizationData.java
@@ -20,6 +20,8 @@ import android.content.ContentProviderOperation;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * {@link OrganizationData} which doesn't add any values. This has package scope because it's not supposed to be used by developers.
@@ -33,7 +35,7 @@ final class EmptyOrganizationData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         // add content item type here, so other organization data can just delegate this part
         return builder

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/JobData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/JobData.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -53,9 +54,9 @@ public final class JobData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.Organization.JOB_DESCRIPTION, mJobDescription == null ? null : mJobDescription.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/OfficeLocationData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/OfficeLocationData.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -53,9 +54,9 @@ public final class OfficeLocationData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.Organization.OFFICE_LOCATION, mOfficeLocation == null ? null : mOfficeLocation.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/PhoneticNameData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/PhoneticNameData.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -53,9 +54,9 @@ public final class PhoneticNameData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.Organization.PHONETIC_NAME, mPhoneticName == null ? null : mPhoneticName.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/SymbolData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/SymbolData.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -53,8 +54,9 @@ public final class SymbolData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(ContactsContract.CommonDataKinds.Organization.SYMBOL, mSymbol == null ? null : mSymbol.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(ContactsContract.CommonDataKinds.Organization.SYMBOL, mSymbol == null ? null : mSymbol.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/TitleData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/TitleData.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -53,8 +54,9 @@ public final class TitleData implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder).withValue(ContactsContract.CommonDataKinds.Organization.TITLE, mTitle == null ? null : mTitle.toString());
+        return mDelegate.updatedBuilder(transactionContext, builder)
+                .withValue(ContactsContract.CommonDataKinds.Organization.TITLE, mTitle == null ? null : mTitle.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/WorkOrganization.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/WorkOrganization.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
 import org.dmfs.iterables.ArrayIterable;
 
@@ -68,8 +69,8 @@ public final class WorkOrganization implements OrganizationData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder);
+        return mDelegate.updatedBuilder(transactionContext, builder);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/phone/PhoneData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/phone/PhoneData.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -45,7 +46,7 @@ public final class PhoneData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Phone.MIMETYPE, ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/photo/PhotoData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/photo/PhotoData.java
@@ -21,6 +21,7 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -41,7 +42,7 @@ public final class PhotoData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Photo.MIMETYPE, ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/CityData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/CityData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * The City of a {@link ContactsContract.CommonDataKinds.StructuredPostal} row.
@@ -48,9 +50,9 @@ public final class CityData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredPostal.CITY, mCity == null ? null : mCity.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/CountryData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/CountryData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * The Country of a {@link ContactsContract.CommonDataKinds.StructuredPostal} row.
@@ -48,9 +50,9 @@ public final class CountryData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredPostal.COUNTRY, mCountry == null ? null : mCountry.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/EmptyPostalData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/EmptyPostalData.java
@@ -20,6 +20,8 @@ import android.content.ContentProviderOperation;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * {@link StructuredPostalData} which doesn't add any values. This has package scope because it's not supposed to be used by developers.
@@ -33,7 +35,7 @@ final class EmptyPostalData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         // add content item type here, so other postal data can just delegate this part
         return builder

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/FullPostalData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/FullPostalData.java
@@ -24,6 +24,7 @@ import android.support.annotation.Nullable;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
 
 
@@ -55,8 +56,8 @@ public final class FullPostalData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder);
+        return mDelegate.updatedBuilder(transactionContext, builder);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/HomePostal.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/HomePostal.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
 import org.dmfs.iterables.ArrayIterable;
 
@@ -68,8 +69,8 @@ public final class HomePostal implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder);
+        return mDelegate.updatedBuilder(transactionContext, builder);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/NeighborhoodData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/NeighborhoodData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * The Neighborhood of a {@link ContactsContract.CommonDataKinds.StructuredPostal} row.
@@ -48,9 +50,9 @@ public final class NeighborhoodData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredPostal.NEIGHBORHOOD, mNeighborhood == null ? null : mNeighborhood.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/PoBoxData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/PoBoxData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * The PoBox of a {@link ContactsContract.CommonDataKinds.StructuredPostal} row.
@@ -48,9 +50,9 @@ public final class PoBoxData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredPostal.POBOX, mPoBox == null ? null : mPoBox.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/PostcodeData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/PostcodeData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * The Postcode of a {@link ContactsContract.CommonDataKinds.StructuredPostal} row.
@@ -48,9 +50,9 @@ public final class PostcodeData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredPostal.POSTCODE, mPostcode == null ? null : mPostcode.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/RegionData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/RegionData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * The Region of a {@link ContactsContract.CommonDataKinds.StructuredPostal} row.
@@ -48,9 +50,9 @@ public final class RegionData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredPostal.REGION, mRegion == null ? null : mRegion.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/SimplePostalData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/SimplePostalData.java
@@ -24,6 +24,7 @@ import android.support.annotation.Nullable;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
 
 
@@ -55,8 +56,8 @@ public final class SimplePostalData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder);
+        return mDelegate.updatedBuilder(transactionContext, builder);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/StreetData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/StreetData.java
@@ -21,6 +21,8 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.dmfs.android.contentpal.TransactionContext;
+
 
 /**
  * The Street of a {@link ContactsContract.CommonDataKinds.StructuredPostal} row.
@@ -48,9 +50,9 @@ public final class StreetData implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder)
+        return mDelegate.updatedBuilder(transactionContext, builder)
                 .withValue(ContactsContract.CommonDataKinds.StructuredPostal.STREET, mStreet == null ? null : mStreet.toString());
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/WorkPostal.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/WorkPostal.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
 import org.dmfs.iterables.ArrayIterable;
 
@@ -68,8 +69,8 @@ public final class WorkPostal implements StructuredPostalData
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(builder);
+        return mDelegate.updatedBuilder(transactionContext, builder);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/relation/RelationData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/relation/RelationData.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -46,7 +47,7 @@ public final class RelationData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Relation.MIMETYPE, ContactsContract.CommonDataKinds.Relation.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/sip/SipAddressData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/sip/SipAddressData.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -45,7 +46,7 @@ public final class SipAddressData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.SipAddress.MIMETYPE, ContactsContract.CommonDataKinds.SipAddress.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/website/WebsiteData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/website/WebsiteData.java
@@ -23,6 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contactspal.data.Custom;
 import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -45,7 +46,7 @@ public final class WebsiteData implements RowData<ContactsContract.Data>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder
                 .withValue(ContactsContract.CommonDataKinds.Website.MIMETYPE, ContactsContract.CommonDataKinds.Website.CONTENT_ITEM_TYPE)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rawcontacts/CleanData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rawcontacts/CleanData.java
@@ -21,6 +21,7 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -32,7 +33,7 @@ public final class CleanData implements RowData<ContactsContract.RawContacts>
 {
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         return builder.withValue(ContactsContract.RawContacts.DIRTY, 0);
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/RowData.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/RowData.java
@@ -37,11 +37,13 @@ public interface RowData<T>
      * Note that {@link ContentProviderOperation.Builder}s are mutable an can not be cloned, so you'll receive the same instance you passed to this method. Make
      * sure you don't rely on the old state of the builder and don't use it in concurrent threads.
      *
+     * @param transactionContext
+     *         The {@link TransactionContext} of the {@link Transaction} this is being executed in.
      * @param builder
      *         A {@link ContentProviderOperation.Builder}.
      *
      * @return The same {@link ContentProviderOperation.Builder}.
      */
     @NonNull
-    ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder);
+    ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder);
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkUpdate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkUpdate.java
@@ -69,6 +69,7 @@ public final class BulkUpdate<T> implements Operation<T>
     @Override
     public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
     {
-        return mData.updatedBuilder(mTable.updateOperation(EmptyUriParams.INSTANCE, mPredicate).contentOperationBuilder(transactionContext));
+        return mData.updatedBuilder(transactionContext,
+                mTable.updateOperation(EmptyUriParams.INSTANCE, mPredicate).contentOperationBuilder(transactionContext));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Insert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Insert.java
@@ -78,6 +78,6 @@ public final class Insert<T> implements InsertOperation<T>
     @Override
     public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
     {
-        return mData.updatedBuilder(mTable.insertOperation(EmptyUriParams.INSTANCE).contentOperationBuilder(transactionContext));
+        return mData.updatedBuilder(transactionContext, mTable.insertOperation(EmptyUriParams.INSTANCE).contentOperationBuilder(transactionContext));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Populated.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Populated.java
@@ -56,6 +56,6 @@ public final class Populated<T> implements Operation<T>
     @Override
     public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mRowData.updatedBuilder(mOperation.contentOperationBuilder(transactionContext));
+        return mRowData.updatedBuilder(transactionContext, mOperation.contentOperationBuilder(transactionContext));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Put.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Put.java
@@ -65,6 +65,6 @@ public final class Put<T> implements Operation<T>
     @Override
     public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mData.updatedBuilder(transactionContext.resolved(mRowSnapshot.reference()).putOperationBuilder(transactionContext));
+        return mData.updatedBuilder(transactionContext, transactionContext.resolved(mRowSnapshot.reference()).putOperationBuilder(transactionContext));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowdata/Composite.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowdata/Composite.java
@@ -20,6 +20,7 @@ import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.iterable.PresentValues;
@@ -57,11 +58,11 @@ public final class Composite<T> implements RowData<T>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         for (RowData<T> rowData : mDelegates)
         {
-            rowData.updatedBuilder(builder);
+            rowData.updatedBuilder(transactionContext, builder);
         }
         return builder;
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowdata/EmptyRowData.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowdata/EmptyRowData.java
@@ -20,6 +20,7 @@ import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -43,7 +44,7 @@ public final class EmptyRowData<T> implements RowData<T>
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(@NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
         // nothing to add
         return builder;


### PR DESCRIPTION
Having the TransactionContext available in `RowData.updatedBuilder(…)` allows to add references to virtual `RowSnapshot`s. This is necessary to add foreign keys to rows which are inserted earlier in the same transaction.