### PR TITLE
Support for Assert operation. #5

### DIFF
--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/CalendarEvent.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/CalendarEvent.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.calendarpal.tables.Events;
 import org.dmfs.android.contentpal.InsertOperation;
+import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.Table;
@@ -39,7 +40,7 @@ import org.dmfs.optional.Optional;
  */
 public final class CalendarEvent implements InsertOperation<CalendarContract.Events>
 {
-    private final InsertOperation<CalendarContract.Events> mDelegate;
+    private final Operation<CalendarContract.Events> mDelegate;
 
 
     /**
@@ -63,7 +64,7 @@ public final class CalendarEvent implements InsertOperation<CalendarContract.Eve
 
     public CalendarEvent(@NonNull RowSnapshot<CalendarContract.Calendars> calendar, @NonNull InsertOperation<CalendarContract.Events> delegate)
     {
-        this.mDelegate = new Related<>(calendar, CalendarContract.Events.CALENDAR_ID, delegate);
+        mDelegate = new Related<>(calendar, CalendarContract.Events.CALENDAR_ID, delegate);
     }
 
 

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/tables/CalendarScoped.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/tables/CalendarScoped.java
@@ -72,8 +72,7 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
     @Override
     public Operation<CalendarContract.Events> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.updateOperation(uriParams, new AllOf(predicate, new EqArg(CalendarContract.Events.CALENDAR_ID, mCalendarRow.values().charData(
-                CalendarContract.Calendars._ID).value("-1"))));
+        return mDelegate.updateOperation(uriParams, calendarScoped(predicate));
     }
 
 
@@ -81,8 +80,15 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
     @Override
     public Operation<CalendarContract.Events> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.deleteOperation(uriParams, new AllOf(predicate, new EqArg(CalendarContract.Events.CALENDAR_ID, mCalendarRow.values().charData(
-                CalendarContract.Calendars._ID).value("-1"))));
+        return mDelegate.deleteOperation(uriParams, calendarScoped(predicate));
+    }
+
+
+    @NonNull
+    @Override
+    public Operation<CalendarContract.Events> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return mDelegate.assertOperation(uriParams, calendarScoped(predicate));
     }
 
 
@@ -91,5 +97,12 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
     public View<CalendarContract.Events> view(@NonNull ContentProviderClient client, @NonNull String... projection)
     {
         return new org.dmfs.android.calendarpal.views.CalendarScoped(mCalendarRow, mDelegate.view(client, projection));
+    }
+
+
+    private Predicate calendarScoped(@NonNull Predicate predicate)
+    {
+        return new AllOf(predicate, new EqArg(CalendarContract.Events.CALENDAR_ID,
+                mCalendarRow.values().charData(CalendarContract.Calendars._ID).value("-1")));
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/operations/RawContactData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/operations/RawContactData.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contactspal.tables.Data;
 import org.dmfs.android.contentpal.InsertOperation;
+import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.Table;
@@ -38,7 +39,7 @@ import org.dmfs.optional.Optional;
  */
 public final class RawContactData implements InsertOperation<ContactsContract.Data>
 {
-    private final InsertOperation<ContactsContract.Data> mDelegate;
+    private final Operation<ContactsContract.Data> mDelegate;
 
 
     public RawContactData(@NonNull RowSnapshot<ContactsContract.RawContacts> rawContact)

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
@@ -73,6 +73,14 @@ public final class AggregationExceptions implements Table<ContactsContract.Aggre
 
     @NonNull
     @Override
+    public Operation<ContactsContract.AggregationExceptions> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return mDelegate.assertOperation(uriParams, predicate);
+    }
+
+
+    @NonNull
+    @Override
     public View<ContactsContract.AggregationExceptions> view(@NonNull ContentProviderClient client, @NonNull String... projection)
     {
         return mDelegate.view(client, projection);

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
@@ -63,7 +63,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
     @Override
     public Operation<ContactsContract.RawContacts> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.updateOperation(uriParams, accountLess(predicate));
+        return mDelegate.updateOperation(uriParams, localAccountPredicate(predicate));
     }
 
 
@@ -71,7 +71,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
     @Override
     public Operation<ContactsContract.RawContacts> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.deleteOperation(uriParams, accountLess(predicate));
+        return mDelegate.deleteOperation(uriParams, localAccountPredicate(predicate));
     }
 
 
@@ -79,7 +79,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
     @Override
     public Operation<ContactsContract.RawContacts> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.assertOperation(uriParams, accountLess(predicate));
+        return mDelegate.assertOperation(uriParams, localAccountPredicate(predicate));
     }
 
 
@@ -91,7 +91,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
     }
 
 
-    private Predicate accountLess(Predicate predicate)
+    private Predicate localAccountPredicate(Predicate predicate)
     {
         return new AllOf(predicate, new IsNull("account_name"), new IsNull("account_type"));
     }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
@@ -63,7 +63,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
     @Override
     public Operation<ContactsContract.RawContacts> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.updateOperation(uriParams, new AllOf(predicate, new IsNull("account_name"), new IsNull("account_type")));
+        return mDelegate.updateOperation(uriParams, accountLess(predicate));
     }
 
 
@@ -71,7 +71,15 @@ public final class Local implements Table<ContactsContract.RawContacts>
     @Override
     public Operation<ContactsContract.RawContacts> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.deleteOperation(uriParams, new AllOf(predicate, new IsNull("account_name"), new IsNull("account_type")));
+        return mDelegate.deleteOperation(uriParams, accountLess(predicate));
+    }
+
+
+    @NonNull
+    @Override
+    public Operation<ContactsContract.RawContacts> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return mDelegate.assertOperation(uriParams, accountLess(predicate));
     }
 
 
@@ -80,5 +88,11 @@ public final class Local implements Table<ContactsContract.RawContacts>
     public View<ContactsContract.RawContacts> view(@NonNull ContentProviderClient client, @NonNull String... projection)
     {
         return new org.dmfs.android.contactspal.views.Local(mDelegate.view(client, projection));
+    }
+
+
+    private Predicate accountLess(Predicate predicate)
+    {
+        return new AllOf(predicate, new IsNull("account_name"), new IsNull("account_type"));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/RowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/RowReference.java
@@ -44,7 +44,7 @@ public interface RowReference<T>
     ContentProviderOperation.Builder putOperationBuilder(@NonNull TransactionContext transactionContext);
 
     /**
-     * Creates an {@link ContentProviderOperation.Builder} that will deleteOperation the referred row.
+     * Creates an {@link ContentProviderOperation.Builder} that will delete the referred row.
      *
      * @param transactionContext
      *         A {@link TransactionContext} of the {@link Transaction} this is being executed in.
@@ -56,6 +56,20 @@ public interface RowReference<T>
      */
     @NonNull
     ContentProviderOperation.Builder deleteOperationBuilder(@NonNull TransactionContext transactionContext);
+
+    /**
+     * Creates an {@link ContentProviderOperation.Builder} that will assert on the referred row.
+     *
+     * @param transactionContext
+     *         A {@link TransactionContext} of the {@link Transaction} this is being executed in.
+     *
+     * @return A {@link ContentProviderOperation.Builder}.
+     *
+     * @throws IllegalStateException
+     *         if the {@link RowReference} doesn't refer to an existing row.
+     */
+    @NonNull
+    ContentProviderOperation.Builder assertOperationBuilder(@NonNull TransactionContext transactionContext);
 
     /**
      * Select the referred item in the given {@link ContentProviderOperation.Builder}.

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/Table.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/Table.java
@@ -66,6 +66,18 @@ public interface Table<T>
     Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate);
 
     /**
+     * Returns an {@link Operation} to assert rows of this table.
+     *
+     * @param uriParams
+     *         Additional parameters to add to the delete {@link Uri}.
+     *
+     * @param predicate
+     * @return An {@link Operation} for this table.
+     */
+    @NonNull
+    Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate);
+
+    /**
      * Returns a {@link View} on this table.
      *
      * @param client

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Assert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Assert.java
@@ -20,54 +20,29 @@ import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Operation;
-import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
-import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.android.contentpal.predicates.AnyOf;
-import org.dmfs.android.contentpal.rowdata.EmptyRowData;
-import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 
 
 /**
- * An {@link Operation} for an assert query which checks that the given {@link RowData} is present in the given {@link Table}
- * filtered by the given {@link Predicate}.
+ * An {@link Operation} for an assert query which checks that the given row referred by {@link RowSnapshot} has the provided {@link RowData}.
  *
  * @author Gabor Keszthelyi
  */
 public final class Assert<T> implements Operation<T>
 {
-    private final Table<T> mTable;
+    private final RowSnapshot<T> mRowSnapshot;
     private final RowData<T> mRowData;
-    private final Predicate mPredicate;
 
 
-    public Assert(Table<T> table, RowData<T> rowData, Predicate predicate)
+    public Assert(RowSnapshot<T> rowSnapshot, RowData<T> rowData)
     {
-        mTable = table;
+        mRowSnapshot = rowSnapshot;
         mRowData = rowData;
-        mPredicate = predicate;
-    }
-
-
-    public Assert(Table<T> table, RowData<T> rowData)
-    {
-        this(table, rowData, new AnyOf());
-    }
-
-
-    public Assert(Table<T> table, Predicate predicate)
-    {
-        this(table, new EmptyRowData<T>(), predicate);
-    }
-
-
-    public Assert(Table<T> table)
-    {
-        this(table, new EmptyRowData<T>(), new AnyOf());
     }
 
 
@@ -84,6 +59,6 @@ public final class Assert<T> implements Operation<T>
     public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
     {
         return mRowData.updatedBuilder(transactionContext,
-                mTable.assertOperation(EmptyUriParams.INSTANCE, mPredicate).contentOperationBuilder(transactionContext));
+                transactionContext.resolved(mRowSnapshot.reference()).assertOperationBuilder(transactionContext));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Assert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Assert.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.android.contentpal.predicates.AnyOf;
+import org.dmfs.android.contentpal.rowdata.EmptyRowData;
+import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
+import org.dmfs.optional.Absent;
+import org.dmfs.optional.Optional;
+
+
+/**
+ * An {@link Operation} for an assert query which checks that the given {@link RowData} is present in the given {@link Table}
+ * filtered by the given {@link Predicate}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Assert<T> implements Operation<T>
+{
+    private final Table<T> mTable;
+    private final RowData<T> mRowData;
+    private final Predicate mPredicate;
+
+
+    public Assert(Table<T> table, RowData<T> rowData, Predicate predicate)
+    {
+        mTable = table;
+        mRowData = rowData;
+        mPredicate = predicate;
+    }
+
+
+    public Assert(Table<T> table, RowData<T> rowData)
+    {
+        this(table, rowData, new AnyOf());
+    }
+
+
+    public Assert(Table<T> table, Predicate predicate)
+    {
+        this(table, new EmptyRowData<T>(), predicate);
+    }
+
+
+    public Assert(Table<T> table)
+    {
+        this(table, new EmptyRowData<T>(), new AnyOf());
+    }
+
+
+    @NonNull
+    @Override
+    public Optional<SoftRowReference<T>> reference()
+    {
+        return Absent.absent();
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
+    {
+        return mRowData.updatedBuilder(transactionContext,
+                mTable.assertOperation(EmptyUriParams.INSTANCE, mPredicate).contentOperationBuilder(transactionContext));
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/AssertRow.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/AssertRow.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.optional.Absent;
+import org.dmfs.optional.Optional;
+
+
+/**
+ * An {@link Operation} for an assert query which checks that the given row referred by {@link RowSnapshot} has the provided {@link RowData}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class AssertRow<T> implements Operation<T>
+{
+    private final RowSnapshot<T> mRowSnapshot;
+    private final RowData<T> mRowData;
+
+
+    public AssertRow(RowSnapshot<T> rowSnapshot, RowData<T> rowData)
+    {
+        mRowSnapshot = rowSnapshot;
+        mRowData = rowData;
+    }
+
+
+    @NonNull
+    @Override
+    public Optional<SoftRowReference<T>> reference()
+    {
+        return Absent.absent();
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
+    {
+        return mRowData.updatedBuilder(transactionContext,
+                transactionContext.resolved(mRowSnapshot.reference()).assertOperationBuilder(transactionContext));
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Related.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Related.java
@@ -20,6 +20,7 @@ import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.InsertOperation;
+import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
@@ -32,14 +33,14 @@ import org.dmfs.optional.Optional;
  *
  * @author Marten Gajda
  */
-public final class Related<T, V> implements InsertOperation<T>
+public final class Related<T, V> implements Operation<T>
 {
-    private final InsertOperation<T> mDelegate;
+    private final Operation<T> mDelegate;
     private final RowSnapshot<V> mRowSnapshot;
     private final String mForeignKeyColumn;
 
 
-    public Related(@NonNull RowSnapshot<V> rowSnapshot, @NonNull String foreignKeyColumn, @NonNull InsertOperation<T> delegate)
+    public Related(@NonNull RowSnapshot<V> rowSnapshot, @NonNull String foreignKeyColumn, @NonNull Operation<T> delegate)
     {
         mDelegate = delegate;
         mRowSnapshot = rowSnapshot;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawAssert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawAssert.java
@@ -14,36 +14,36 @@
  * limitations under the License.
  */
 
-package org.dmfs.android.calendarpal.operations;
+package org.dmfs.android.contentpal.operations.internal;
 
 import android.content.ContentProviderOperation;
-import android.provider.CalendarContract;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 
-import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.Operation;
-import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.android.contentpal.operations.Related;
+import org.dmfs.android.contentpal.operations.Assert;
+import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 
 
 /**
- * {@link InsertOperation} decorator which relates an element of a table &lt;T&gt; to a given event row. The respective table must use {@code "event_id"} as the
- * name of the foreign key column to the event. This is true for {@link CalendarContract.Attendees} and {@link CalendarContract.Reminders}.
+ * An {@link Operation} to assert rows of a given {@link Uri}.
+ * <p>
+ * This is for internal purposes and should not be instantiated directly. Use {@link Assert} instead.
  *
- * @author Marten Gajda
+ * @author Gabor Keszthelyi
  */
-public final class EventRelated<T> implements InsertOperation<T>
+public final class RawAssert<T> implements Operation<T>
 {
 
-    private final Operation<T> mDelegate;
+    private final Uri mUri;
 
 
-    public EventRelated(@NonNull RowSnapshot<CalendarContract.Events> event, @NonNull InsertOperation<T> delegate)
+    public RawAssert(Uri uri)
     {
-        mDelegate = new Related<>(event, "event_id"/* all supported tables use this name as the foreign key column name */, delegate);
+        mUri = uri;
     }
 
 
@@ -51,7 +51,7 @@ public final class EventRelated<T> implements InsertOperation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return mDelegate.reference();
+        return Absent.absent();
     }
 
 
@@ -59,6 +59,6 @@ public final class EventRelated<T> implements InsertOperation<T>
     @Override
     public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
     {
-        return mDelegate.contentOperationBuilder(transactionContext);
+        return ContentProviderOperation.newAssertQuery(mUri);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawAssert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawAssert.java
@@ -24,6 +24,7 @@ import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.Assert;
+import org.dmfs.android.contentpal.operations.BulkAssert;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 
@@ -31,7 +32,7 @@ import org.dmfs.optional.Optional;
 /**
  * An {@link Operation} to assert rows of a given {@link Uri}.
  * <p>
- * This is for internal purposes and should not be instantiated directly. Use {@link Assert} instead.
+ * This is for internal purposes and should not be instantiated directly. Use {@link Assert} or {@link BulkAssert} instead.
  *
  * @author Gabor Keszthelyi
  */

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
@@ -65,6 +65,14 @@ public final class AbsoluteRowReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
+    public ContentProviderOperation.Builder assertOperationBuilder(@NonNull TransactionContext transactionContext)
+    {
+        return mTable.assertOperation(EmptyUriParams.INSTANCE, new EqArg(BaseColumns._ID, rowId())).contentOperationBuilder(transactionContext);
+    }
+
+
+    @NonNull
+    @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         return operationBuilder.withValue(foreignKeyColumn, rowId());

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/BackReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/BackReference.java
@@ -69,6 +69,14 @@ public final class BackReference<T> implements RowReference<T>
 
     @NonNull
     @Override
+    public ContentProviderOperation.Builder assertOperationBuilder(@NonNull TransactionContext transactionContext)
+    {
+        return withSelection(ContentProviderOperation.newAssertQuery(mUri), BaseColumns._ID);
+    }
+
+
+    @NonNull
+    @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         return operationBuilder.withValueBackReference(foreignKeyColumn, mBackReference);

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
@@ -59,6 +59,14 @@ public final class RowSnapshotReference<T> implements RowReference<T>
 
     @NonNull
     @Override
+    public ContentProviderOperation.Builder assertOperationBuilder(@NonNull TransactionContext transactionContext)
+    {
+        return transactionContext.resolved(mRowSnapshot.reference()).assertOperationBuilder(transactionContext);
+    }
+
+
+    @NonNull
+    @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         return transactionContext.resolved(mRowSnapshot.reference()).builderWithReferenceData(transactionContext, operationBuilder, foreignKeyColumn);

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
@@ -61,6 +61,14 @@ public final class RowUriReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
+    public ContentProviderOperation.Builder assertOperationBuilder(@NonNull TransactionContext transactionContext)
+    {
+        return ContentProviderOperation.newAssertQuery(mRowUri);
+    }
+
+
+    @NonNull
+    @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         return operationBuilder.withValue(foreignKeyColumn, rowId());

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
@@ -63,6 +63,14 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
+    public ContentProviderOperation.Builder assertOperationBuilder(@NonNull TransactionContext transactionContext)
+    {
+        throw new UnsupportedOperationException("Can't assert on a virtual row.");
+    }
+
+
+    @NonNull
+    @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
         throw new UnsupportedOperationException("Can't reference a virtual row.");

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
@@ -64,7 +64,7 @@ public final class AccountScoped<T> implements Table<T>
     @Override
     public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.updateOperation(new AccountScopedParams(mAccount, uriParams), predicate(predicate));
+        return mDelegate.updateOperation(new AccountScopedParams(mAccount, uriParams), accountScoped(predicate));
     }
 
 
@@ -72,7 +72,15 @@ public final class AccountScoped<T> implements Table<T>
     @Override
     public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.deleteOperation(new AccountScopedParams(mAccount, uriParams), predicate(predicate));
+        return mDelegate.deleteOperation(new AccountScopedParams(mAccount, uriParams), accountScoped(predicate));
+    }
+
+
+    @NonNull
+    @Override
+    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return mDelegate.assertOperation(new AccountScopedParams(mAccount, uriParams), accountScoped(predicate));
     }
 
 
@@ -84,8 +92,7 @@ public final class AccountScoped<T> implements Table<T>
     }
 
 
-    @NonNull
-    private Predicate predicate(@NonNull Predicate predicate)
+    private Predicate accountScoped(Predicate predicate)
     {
         return new AllOf(predicate, new AccountEq(mAccount));
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
@@ -29,6 +29,7 @@ import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
+import org.dmfs.android.contentpal.operations.internal.RawAssert;
 import org.dmfs.android.contentpal.operations.internal.RawDelete;
 import org.dmfs.android.contentpal.operations.internal.RawInsert;
 import org.dmfs.android.contentpal.operations.internal.RawUpdate;
@@ -79,6 +80,14 @@ public final class BaseTable<T> implements Table<T>
     public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
         return new Constrained<>(new RawDelete<T>(uriParams.withParam(mTableUri.buildUpon()).build()), predicate);
+    }
+
+
+    @NonNull
+    @Override
+    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return new Constrained<>(new RawAssert<T>(uriParams.withParam(mTableUri.buildUpon()).build()), predicate);
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/DelegatingTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/DelegatingTable.java
@@ -72,6 +72,14 @@ public abstract class DelegatingTable<T> implements Table<T>
 
     @NonNull
     @Override
+    public final Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return mDelegate.assertOperation(uriParams, predicate);
+    }
+
+
+    @NonNull
+    @Override
     public final View<T> view(@NonNull ContentProviderClient client, @NonNull String... projection)
     {
         return mDelegate.view(client, projection);

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
@@ -74,6 +74,14 @@ public final class Synced<T> implements Table<T>
 
     @NonNull
     @Override
+    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    {
+        return mDelegate.assertOperation(new SyncParams(uriParams), predicate);
+    }
+
+
+    @NonNull
+    @Override
     public View<T> view(@NonNull ContentProviderClient client, @NonNull String... projection)
     {
         return new org.dmfs.android.contentpal.views.Synced<>(mDelegate.view(client, projection));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/tables/SyncedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/tables/SyncedTest.java
@@ -44,14 +44,14 @@ import static org.mockito.Mockito.mock;
  * @author Marten Gajda
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@Config(manifest = Config.NONE)
 public class SyncedTest
 {
     @Test
     public void testInsertOperation() throws Exception
     {
-        final InsertOperation<Object> resultOperation = mock(InsertOperation.class, new FailAnswer());
-        final Table<Object> mockTable = mock(Table.class, new FailAnswer());
+        InsertOperation<Object> resultOperation = mock(InsertOperation.class, new FailAnswer());
+        Table<Object> mockTable = mock(Table.class, new FailAnswer());
         doReturn(resultOperation).when(mockTable).insertOperation(argThat(new UriParamsArgumentMatcher()));
 
         assertThat(new Synced<>(mockTable).insertOperation(new EmptyUriParams()), sameInstance(resultOperation));
@@ -61,9 +61,9 @@ public class SyncedTest
     @Test
     public void testUpdateOperation() throws Exception
     {
-        final Operation<Object> resultOperation = mock(Operation.class, new FailAnswer());
-        final Predicate testPredicate = mock(Predicate.class);
-        final Table<Object> mockTable = mock(Table.class, new FailAnswer());
+        Operation<Object> resultOperation = mock(Operation.class, new FailAnswer());
+        Predicate testPredicate = mock(Predicate.class);
+        Table<Object> mockTable = mock(Table.class, new FailAnswer());
         doReturn(resultOperation).when(mockTable).updateOperation(argThat(new UriParamsArgumentMatcher()), same(testPredicate));
 
         assertThat(new Synced<>(mockTable).updateOperation(new EmptyUriParams(), testPredicate), sameInstance(resultOperation));
@@ -73,12 +73,24 @@ public class SyncedTest
     @Test
     public void testDeleteOperation() throws Exception
     {
-        final Operation<Object> resultOperation = mock(Operation.class, new FailAnswer());
-        final Predicate testPredicate = mock(Predicate.class);
-        final Table<Object> mockTable = mock(Table.class, new FailAnswer());
+        Operation<Object> resultOperation = mock(Operation.class, new FailAnswer());
+        Predicate testPredicate = mock(Predicate.class);
+        Table<Object> mockTable = mock(Table.class, new FailAnswer());
         doReturn(resultOperation).when(mockTable).deleteOperation(argThat(new UriParamsArgumentMatcher()), same(testPredicate));
 
         assertThat(new Synced<>(mockTable).deleteOperation(new EmptyUriParams(), testPredicate), sameInstance(resultOperation));
+    }
+
+
+    @Test
+    public void testAssertOperation() throws Exception
+    {
+        Operation<Object> resultOperation = mock(Operation.class, new FailAnswer());
+        Predicate testPredicate = mock(Predicate.class);
+        Table<Object> mockTable = mock(Table.class, new FailAnswer());
+        doReturn(resultOperation).when(mockTable).assertOperation(argThat(new UriParamsArgumentMatcher()), same(testPredicate));
+
+        assertThat(new Synced<>(mockTable).assertOperation(new EmptyUriParams(), testPredicate), sameInstance(resultOperation));
     }
 
 
@@ -91,4 +103,5 @@ public class SyncedTest
             return uri.getBooleanQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, false);
         }
     }
+
 }


### PR DESCRIPTION
Submitting for initial review, but I haven't yet tried `Assert` with the secondary constructors for example in OpenTask tests, not sure how they will work (how to test for no row or empty table).

So I may be adding more commits to this, and also I will probably have to rebase after other PRs are merged as well.