### PR TITLE
Fix resolution of VirtualRowSnapshots. Fixes #37

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -44,7 +44,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
@@ -45,7 +45,7 @@ public final class RowSnapshotReference<T> implements RowReference<T>
     @Override
     public ContentProviderOperation.Builder putOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mRowSnapshot.reference().putOperationBuilder(transactionContext);
+        return transactionContext.resolved(mRowSnapshot.reference()).putOperationBuilder(transactionContext);
     }
 
 
@@ -53,7 +53,7 @@ public final class RowSnapshotReference<T> implements RowReference<T>
     @Override
     public ContentProviderOperation.Builder deleteOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mRowSnapshot.reference().deleteOperationBuilder(transactionContext);
+        return transactionContext.resolved(mRowSnapshot.reference()).deleteOperationBuilder(transactionContext);
     }
 
 
@@ -61,7 +61,7 @@ public final class RowSnapshotReference<T> implements RowReference<T>
     @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
-        return mRowSnapshot.reference().builderWithReferenceData(transactionContext, operationBuilder, foreignKeyColumn);
+        return transactionContext.resolved(mRowSnapshot.reference()).builderWithReferenceData(transactionContext, operationBuilder, foreignKeyColumn);
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
@@ -65,7 +65,7 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
     @Override
     public ContentProviderOperation.Builder builderWithReferenceData(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder operationBuilder, @NonNull String foreignKeyColumn)
     {
-        return transactionContext.resolved(this).builderWithReferenceData(transactionContext, operationBuilder, foreignKeyColumn);
+        throw new UnsupportedOperationException("Can't reference a virtual row.");
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/contexts/EmptyTransactionContext.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/contexts/EmptyTransactionContext.java
@@ -38,11 +38,6 @@ public final class EmptyTransactionContext implements TransactionContext
     @Override
     public <T> RowReference<T> resolved(@NonNull SoftRowReference<T> reference)
     {
-        if (reference.isVirtual())
-        {
-            // we need to throw here, otherwise we might end up in an infinite loop
-            throw new IllegalArgumentException(String.format("Unable to resolve virtual RowReference %s", reference));
-        }
         return reference;
     }
 


### PR DESCRIPTION
This fixes how VirtualRowReferences are resolved when calling `builderWithReferenceData`. The actual issue was that `RowSnapshotReference` didn't resolve the reference. Now the exception in `EmptyTransactionContext` is not necessary anymore.