### PR TITLE
Add RelatedTo predicate. Implements #46

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -44,7 +44,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -8,6 +8,7 @@
       <module fileurl="file://$PROJECT_DIR$/contactspal/contactspal.iml" filepath="$PROJECT_DIR$/contactspal/contactspal.iml" />
       <module fileurl="file://$PROJECT_DIR$/contentpal/contentpal.iml" filepath="$PROJECT_DIR$/contentpal/contentpal.iml" />
       <module fileurl="file://$PROJECT_DIR$/contenttestpal/contenttestpal.iml" filepath="$PROJECT_DIR$/contenttestpal/contenttestpal.iml" />
+      <module fileurl="file://$PROJECT_DIR$/contenttestpal/contenttestpal.iml" filepath="$PROJECT_DIR$/contenttestpal/contenttestpal.iml" />
     </modules>
   </component>
 </project>

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/Predicate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/Predicate.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 
@@ -29,14 +30,35 @@ public interface Predicate
     /**
      * Returns an SQL selection CharSequence which selects elements matching this predicate.
      *
+     * @param transactionContext
+     *         The {@link TransactionContext} of the Transaction this is executed in.
+     *
      * @return
      */
     @NonNull
-    CharSequence selection();
+    CharSequence selection(@NonNull TransactionContext transactionContext);
 
     /**
      * An {@link Iterable} of all arguments of this predicate.
+     *
+     * @param transactionContext
+     *         The {@link TransactionContext} of the Transaction this is executed in.
      */
     @NonNull
-    Iterable<String> arguments();
+    Iterable<String> arguments(@NonNull TransactionContext transactionContext);
+
+    /**
+     * Updates the selection of the given {@link ContentProviderOperation.Builder} with any back references.
+     *
+     * @param transactionContext
+     *         The current {@link TransactionContext}
+     * @param builder
+     *         The {@link ContentProviderOperation.Builder} to update.
+     * @param argOffset
+     *         The offset of the argument of this Predicate in the arguments array.
+     *
+     * @return The given {@link ContentProviderOperation.Builder}.
+     */
+    @NonNull
+    ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset);
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/RowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/RowReference.java
@@ -86,10 +86,11 @@ public interface RowReference<T>
     /**
      * Returns a {@link Predicate} which matches the row on the given key column.
      *
+     * @param transactionContext
      * @param keyColumn
      *
      * @return A {@link Predicate}
      */
     @NonNull
-    Predicate predicate(@NonNull String keyColumn);
+    Predicate predicate(TransactionContext transactionContext, @NonNull String keyColumn);
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/DelegatingPredicate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/DelegatingPredicate.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -39,16 +41,24 @@ public abstract class DelegatingPredicate implements Predicate
 
     @NonNull
     @Override
-    public final CharSequence selection()
+    public final CharSequence selection(@NonNull TransactionContext transactionContext)
     {
-        return mDelegate.selection();
+        return mDelegate.selection(transactionContext);
     }
 
 
     @NonNull
     @Override
-    public final Iterable<String> arguments()
+    public final Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
-        return mDelegate.arguments();
+        return mDelegate.arguments(transactionContext);
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return mDelegate.updatedBuilder(transactionContext, builder, argOffset);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqArg.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqArg.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.SingletonIterable;
 
 
@@ -42,7 +44,7 @@ public final class EqArg implements Predicate
 
     @NonNull
     @Override
-    public CharSequence selection()
+    public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
         return new StringBuilder(mColumnName).append(" = ?");
     }
@@ -50,8 +52,16 @@ public final class EqArg implements Predicate
 
     @NonNull
     @Override
-    public Iterable<String> arguments()
+    public Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
         return new SingletonIterable<>(mArgument.toString());
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return builder;
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqCol.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqCol.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.EmptyIterable;
 
 
@@ -40,7 +42,7 @@ public final class EqCol implements Predicate
 
     @NonNull
     @Override
-    public CharSequence selection()
+    public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
         return new StringBuilder(mColumn1Name.length() + 3 + mColumn2Name.length()).append(mColumn1Name).append(" = ").append(mColumn2Name);
     }
@@ -48,8 +50,16 @@ public final class EqCol implements Predicate
 
     @NonNull
     @Override
-    public Iterable<String> arguments()
+    public Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
         return EmptyIterable.instance();
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return builder;
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/IsNull.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/IsNull.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.EmptyIterable;
 
 
@@ -40,7 +42,7 @@ public final class IsNull implements Predicate
 
     @NonNull
     @Override
-    public CharSequence selection()
+    public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
         return new StringBuilder(mColumnName).append(" is null");
     }
@@ -48,8 +50,16 @@ public final class IsNull implements Predicate
 
     @NonNull
     @Override
-    public Iterable<String> arguments()
+    public Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
         return EmptyIterable.instance();
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return builder;
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/LikeArg.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/LikeArg.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.SingletonIterable;
 
 
@@ -42,7 +44,7 @@ public final class LikeArg implements Predicate
 
     @NonNull
     @Override
-    public CharSequence selection()
+    public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
         return new StringBuilder(mColumnName).append(" like ?");
     }
@@ -50,8 +52,16 @@ public final class LikeArg implements Predicate
 
     @NonNull
     @Override
-    public Iterable<String> arguments()
+    public Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
         return new SingletonIterable<>(mArgument.toString());
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return builder;
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/Not.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/Not.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
@@ -37,17 +39,25 @@ public final class Not implements Predicate
 
     @NonNull
     @Override
-    public CharSequence selection()
+    public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
-        CharSequence subSelection = mPredicate.selection();
+        CharSequence subSelection = mPredicate.selection(transactionContext);
         return new StringBuilder(subSelection.length() + 10).append("not ( ").append(subSelection).append(" )");
     }
 
 
     @NonNull
     @Override
-    public Iterable<String> arguments()
+    public Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
-        return mPredicate.arguments();
+        return mPredicate.arguments(transactionContext);
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return mPredicate.updatedBuilder(transactionContext, builder, argOffset);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/NotNull.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/NotNull.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.EmptyIterable;
 
 
@@ -38,7 +40,7 @@ public final class NotNull implements Predicate
 
     @NonNull
     @Override
-    public CharSequence selection()
+    public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
         return new StringBuilder(mColumnName).append(" is not null");
     }
@@ -46,8 +48,16 @@ public final class NotNull implements Predicate
 
     @NonNull
     @Override
-    public Iterable<String> arguments()
+    public Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
         return EmptyIterable.instance();
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return builder;
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
@@ -81,7 +81,7 @@ public final class AbsoluteRowReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull String keyColumn)
+    public Predicate predicate(TransactionContext transactionContext, @NonNull String keyColumn)
     {
         return new EqArg(keyColumn, rowId());
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
@@ -75,8 +75,8 @@ public final class RowSnapshotReference<T> implements RowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull String keyColumn)
+    public Predicate predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
     {
-        return mRowSnapshot.reference().predicate(keyColumn);
+        return transactionContext.resolved(mRowSnapshot.reference()).predicate(transactionContext, keyColumn);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
@@ -77,7 +77,7 @@ public final class RowUriReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull String keyColumn)
+    public Predicate predicate(TransactionContext transactionContext, @NonNull String keyColumn)
     {
         return new EqArg(keyColumn, rowId());
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
@@ -79,7 +79,7 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull String keyColumn)
+    public Predicate predicate(TransactionContext transactionContext, @NonNull String keyColumn)
     {
         throw new UnsupportedOperationException("Can't create a predicate which matches a virtual row.");
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
@@ -30,6 +30,7 @@ import org.dmfs.android.contentpal.rowsnapshots.ValuesRowSnapshot;
 import org.dmfs.android.contentpal.tools.ClosableEmptyIterator;
 import org.dmfs.android.contentpal.tools.ClosableIterator;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.dmfs.iterators.AbstractBaseIterator;
 import org.dmfs.optional.Absent;
 
@@ -76,7 +77,7 @@ public final class QueryRowSet<T> implements RowSet<T>
             throw new RuntimeException(
                     String.format("Unable to execute query on view \"%s\" with selection \"%s\"",
                             mView.toString(),
-                            mPredicate.selection().toString()), e);
+                            mPredicate.selection(EmptyTransactionContext.INSTANCE).toString()), e);
         }
     }
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
@@ -133,12 +133,15 @@ public final class BaseTable<T> implements Table<T>
         public ContentProviderOperation.Builder contentOperationBuilder(@NonNull TransactionContext transactionContext) throws UnsupportedOperationException
         {
             List<String> arguments = new LinkedList<>();
-            for (String arg : mPredicate.arguments())
+            for (String arg : mPredicate.arguments(transactionContext))
             {
                 arguments.add(arg);
             }
-            return mDelegate.contentOperationBuilder(transactionContext)
-                    .withSelection(mPredicate.selection().toString(), arguments.toArray(new String[arguments.size()]));
+            return mPredicate.updatedBuilder(
+                    transactionContext,
+                    mDelegate.contentOperationBuilder(transactionContext)
+                            .withSelection(mPredicate.selection(transactionContext).toString(), arguments.toArray(new String[arguments.size()])),
+                    0);
         }
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tools/Length.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tools/Length.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.tools;
+
+/**
+ * The length of an {@link Iterable}.
+ *
+ * @author Marten Gajda
+ */
+public final class Length extends Number
+{
+    private final Iterable<?> mIterable;
+
+    private int mLength = -1;
+
+
+    public Length(Iterable<?> iterable)
+    {
+        mIterable = iterable;
+    }
+
+
+    @Override
+    public int intValue()
+    {
+        return length();
+    }
+
+
+    @Override
+    public long longValue()
+    {
+        return length();
+    }
+
+
+    @Override
+    public float floatValue()
+    {
+        return length();
+    }
+
+
+    @Override
+    public double doubleValue()
+    {
+        return length();
+    }
+
+
+    private int length()
+    {
+        if (mLength < 0)
+        {
+            int len = 0;
+            for (Object o : mIterable)
+            {
+                len += 1;
+            }
+            mLength = len;
+        }
+        return mLength;
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/BaseView.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/BaseView.java
@@ -28,6 +28,7 @@ import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.tables.BaseTable;
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.dmfs.optional.Optional;
 
 import java.util.LinkedList;
@@ -62,13 +63,13 @@ public final class BaseView<T> implements View<T>
     public Cursor rows(@NonNull UriParams uriParams, @NonNull final Predicate predicate, @NonNull final Optional<String> sorting) throws RemoteException
     {
         List<String> args = new LinkedList<>();
-        for (String arg : predicate.arguments())
+        for (String arg : predicate.arguments(EmptyTransactionContext.INSTANCE))
         {
             args.add(arg);
         }
         Cursor cursor = mClient.query(uriParams.withParam(mTableUri.buildUpon()).build(),
                 mProjection,
-                predicate.selection().toString(),
+                predicate.selection(EmptyTransactionContext.INSTANCE).toString(),
                 args.toArray(new String[args.size()]),
                 sorting.value(null /* fallback: null */));
         return cursor == null ? new MatrixCursor(mProjection) : cursor;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AllOfTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AllOfTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -33,19 +34,21 @@ public class AllOfTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("1", new AllOf().selection().toString());
-        assertEquals("x", new AllOf(new Mocked("x", "a")).selection().toString());
-        assertEquals("( x ) and ( y )", new AllOf(new Mocked("x", "a"), new Mocked("y", "1")).selection().toString());
-        assertEquals("( x ) and ( z ) and ( y )", new AllOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).selection().toString());
+        assertEquals("1", new AllOf().selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("x", new AllOf(new Mocked("x", "a")).selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("( x ) and ( y )", new AllOf(new Mocked("x", "a"), new Mocked("y", "1")).selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("( x ) and ( z ) and ( y )",
+                new AllOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new AllOf().arguments(), emptyIterable());
-        assertThat(new AllOf(new Mocked("x", "a")).arguments(), contains("a"));
-        assertThat(new AllOf(new Mocked("x", "a"), new Mocked("y", "1")).arguments(), contains("a", "1"));
-        assertThat(new AllOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).arguments(), contains("a", "w", "z", "1"));
+        assertThat(new AllOf().arguments(EmptyTransactionContext.INSTANCE), emptyIterable());
+        assertThat(new AllOf(new Mocked("x", "a")).arguments(EmptyTransactionContext.INSTANCE), contains("a"));
+        assertThat(new AllOf(new Mocked("x", "a"), new Mocked("y", "1")).arguments(EmptyTransactionContext.INSTANCE), contains("a", "1"));
+        assertThat(new AllOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).arguments(EmptyTransactionContext.INSTANCE),
+                contains("a", "w", "z", "1"));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AnyOfTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AnyOfTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -33,19 +34,21 @@ public class AnyOfTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("1", new AnyOf().selection().toString());
-        assertEquals("x", new AnyOf(new Mocked("x", "a")).selection().toString());
-        assertEquals("( x ) or ( y )", new AnyOf(new Mocked("x", "a"), new Mocked("y", "1")).selection().toString());
-        assertEquals("( x ) or ( z ) or ( y )", new AnyOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).selection().toString());
+        assertEquals("1", new AnyOf().selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("x", new AnyOf(new Mocked("x", "a")).selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("( x ) or ( y )", new AnyOf(new Mocked("x", "a"), new Mocked("y", "1")).selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("( x ) or ( z ) or ( y )",
+                new AnyOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new AnyOf().arguments(), emptyIterable());
-        assertThat(new AnyOf(new Mocked("x", "a")).arguments(), contains("a"));
-        assertThat(new AnyOf(new Mocked("x", "a"), new Mocked("y", "1")).arguments(), contains("a", "1"));
-        assertThat(new AnyOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).arguments(), contains("a", "w", "z", "1"));
+        assertThat(new AnyOf().arguments(EmptyTransactionContext.INSTANCE), emptyIterable());
+        assertThat(new AnyOf(new Mocked("x", "a")).arguments(EmptyTransactionContext.INSTANCE), contains("a"));
+        assertThat(new AnyOf(new Mocked("x", "a"), new Mocked("y", "1")).arguments(EmptyTransactionContext.INSTANCE), contains("a", "1"));
+        assertThat(new AnyOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).arguments(EmptyTransactionContext.INSTANCE),
+                contains("a", "w", "z", "1"));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqArgTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqArgTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -32,13 +33,13 @@ public class EqArgTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("x = ?", new EqArg("x", "y").selection().toString());
+        assertEquals("x = ?", new EqArg("x", "y").selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new EqArg("x", "y").arguments(), contains("y"));
+        assertThat(new EqArg("x", "y").arguments(EmptyTransactionContext.INSTANCE), contains("y"));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqColTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqColTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.emptyIterable;
@@ -32,13 +33,13 @@ public class EqColTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("x = y", new EqCol("x", "y").selection().toString());
+        assertEquals("x = y", new EqCol("x", "y").selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new EqCol("x", "y").arguments(), emptyIterable());
+        assertThat(new EqCol("x", "y").arguments(EmptyTransactionContext.INSTANCE), emptyIterable());
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/InTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/InTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -32,20 +33,20 @@ public class InTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("x in ( ) ", new In("x").selection().toString());
-        assertEquals("x in ( ? ) ", new In("x", "a").selection().toString());
-        assertEquals("x in ( ?, ? ) ", new In("x", "a", 1).selection().toString());
-        assertEquals("x in ( ?, ?, ? ) ", new In("x", "a", 1, 1.2).selection().toString());
+        assertEquals("x in ( ) ", new In("x").selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("x in ( ? ) ", new In("x", "a").selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("x in ( ?, ? ) ", new In("x", "a", 1).selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("x in ( ?, ?, ? ) ", new In("x", "a", 1, 1.2).selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new In("x").arguments(), emptyIterable());
-        assertThat(new In("x", "a").arguments(), contains("a"));
-        assertThat(new In("x", "a", 1).arguments(), contains("a", "1"));
-        assertThat(new In("x", "a", 1, 1.2).arguments(), contains("a", "1", "1.2"));
+        assertThat(new In("x").arguments(EmptyTransactionContext.INSTANCE), emptyIterable());
+        assertThat(new In("x", "a").arguments(EmptyTransactionContext.INSTANCE), contains("a"));
+        assertThat(new In("x", "a", 1).arguments(EmptyTransactionContext.INSTANCE), contains("a", "1"));
+        assertThat(new In("x", "a", 1, 1.2).arguments(EmptyTransactionContext.INSTANCE), contains("a", "1", "1.2"));
     }
 
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/IsNullTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/IsNullTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.emptyIterable;
@@ -32,13 +33,13 @@ public class IsNullTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("x is null", new IsNull("x").selection().toString());
+        assertEquals("x is null", new IsNull("x").selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new IsNull("x").arguments(), emptyIterable());
+        assertThat(new IsNull("x").arguments(EmptyTransactionContext.INSTANCE), emptyIterable());
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/LikeArgTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/LikeArgTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -32,13 +33,13 @@ public class LikeArgTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("x like ?", new LikeArg("x", "y").selection().toString());
+        assertEquals("x like ?", new LikeArg("x", "y").selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new LikeArg("x", "y").arguments(), contains("y"));
+        assertThat(new LikeArg("x", "y").arguments(EmptyTransactionContext.INSTANCE), contains("y"));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/Mocked.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/Mocked.java
@@ -16,9 +16,11 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.ArrayIterable;
 
 
@@ -43,7 +45,7 @@ public final class Mocked implements Predicate
 
     @NonNull
     @Override
-    public CharSequence selection()
+    public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
         return mSelection;
     }
@@ -51,8 +53,16 @@ public final class Mocked implements Predicate
 
     @NonNull
     @Override
-    public Iterable<String> arguments()
+    public Iterable<String> arguments(@NonNull TransactionContext transactionContext)
     {
         return mArguments;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder, int argOffset)
+    {
+        return builder;
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NoneOfTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NoneOfTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -33,20 +34,21 @@ public class NoneOfTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("not ( 1 )", new NoneOf().selection().toString());
-        assertEquals("not ( x )", new NoneOf(new Mocked("x", "a")).selection().toString());
-        assertEquals("not ( ( x ) or ( y ) )", new NoneOf(new Mocked("x", "a"), new Mocked("y", "1")).selection().toString());
+        assertEquals("not ( 1 )", new NoneOf().selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("not ( x )", new NoneOf(new Mocked("x", "a")).selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("not ( ( x ) or ( y ) )", new NoneOf(new Mocked("x", "a"), new Mocked("y", "1")).selection(EmptyTransactionContext.INSTANCE).toString());
         assertEquals("not ( ( x ) or ( z ) or ( y ) )",
-                new NoneOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).selection().toString());
+                new NoneOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new NoneOf().arguments(), emptyIterable());
-        assertThat(new NoneOf(new Mocked("x", "a")).arguments(), contains("a"));
-        assertThat(new NoneOf(new Mocked("x", "a"), new Mocked("y", "1")).arguments(), contains("a", "1"));
-        assertThat(new NoneOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).arguments(), contains("a", "w", "z", "1"));
+        assertThat(new NoneOf().arguments(EmptyTransactionContext.INSTANCE), emptyIterable());
+        assertThat(new NoneOf(new Mocked("x", "a")).arguments(EmptyTransactionContext.INSTANCE), contains("a"));
+        assertThat(new NoneOf(new Mocked("x", "a"), new Mocked("y", "1")).arguments(EmptyTransactionContext.INSTANCE), contains("a", "1"));
+        assertThat(new NoneOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")).arguments(EmptyTransactionContext.INSTANCE),
+                contains("a", "w", "z", "1"));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotNullTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotNullTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.emptyIterable;
@@ -32,13 +33,13 @@ public class NotNullTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("x is not null", new NotNull("x").selection().toString());
+        assertEquals("x is not null", new NotNull("x").selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new NotNull("x").arguments(), emptyIterable());
+        assertThat(new NotNull("x").arguments(EmptyTransactionContext.INSTANCE), emptyIterable());
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotTest.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.predicates;
 
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -32,15 +33,15 @@ public class NotTest
     @Test
     public void testSelection() throws Exception
     {
-        assertEquals("not ( x )", new Not(new Mocked("x", "a")).selection().toString());
-        assertEquals("not ( x )", new Not(new Mocked("x", "a", "z", "w")).selection().toString());
+        assertEquals("not ( x )", new Not(new Mocked("x", "a")).selection(EmptyTransactionContext.INSTANCE).toString());
+        assertEquals("not ( x )", new Not(new Mocked("x", "a", "z", "w")).selection(EmptyTransactionContext.INSTANCE).toString());
     }
 
 
     @Test
     public void testArguments() throws Exception
     {
-        assertThat(new Not(new Mocked("x", "a")).arguments(), contains("a"));
-        assertThat(new Not(new Mocked("x", "a", "z", "w")).arguments(), contains("a", "z", "w"));
+        assertThat(new Not(new Mocked("x", "a")).arguments(EmptyTransactionContext.INSTANCE), contains("a"));
+        assertThat(new Not(new Mocked("x", "a", "z", "w")).arguments(EmptyTransactionContext.INSTANCE), contains("a", "z", "w"));
     }
 }


### PR DESCRIPTION
This commit adds TransactionContext to Predicates in order to resolve related rows dynamically at operation build time.
BaseView currently passes an EmptyTransactionContext which keeps the current behavior. In future versions it might be useful
to add a TransactionContext to `View.rows(…)` to be able to query by rows which have been inserted in a previous transaction.