### PR TITLE
Fix reference resolution. Fixes #64

### DIFF
--- a/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/BaseTransaction.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/BaseTransaction.java
@@ -104,12 +104,16 @@ public final class BaseTransaction implements Transaction
         {
             ContentProviderOperation op = operation.contentOperationBuilder(new Quick(tempTransactionContext)).build();
 
-            // update the transaction context if this operation has a virtual reference
+            // update the transaction context if this operation has a virtual reference which can not be resolved
             Optional<? extends SoftRowReference<?>> optionalReference = operation.reference();
-            if (optionalReference.isPresent() && optionalReference.value().isVirtual())
+            if (optionalReference.isPresent())
             {
-                batchReferences.put(newBatch.size(), optionalReference.value());
-                tempTransactionContext = new Updated(tempTransactionContext, optionalReference.value(), op.getUri(), newBatch.size());
+                SoftRowReference<?> rowReference = optionalReference.value();
+                if (rowReference.isVirtual() && tempTransactionContext.resolved(rowReference) == rowReference)
+                {
+                    batchReferences.put(newBatch.size(), optionalReference.value());
+                    tempTransactionContext = new Updated(tempTransactionContext, optionalReference.value(), op.getUri(), newBatch.size());
+                }
             }
 
             newBatch.add(op);


### PR DESCRIPTION
Only add a rowReference to the temporary and result transaction contexts if it's virtual and can not be resolved otherwise.
Before this, an update or assert of an insert operation resulted in an updated transaction context with follow up resolve operations returning a reference to the update or assert operation, which can not work.