### PR TITLE
Add support for JaCoCo and Codecov.io. Implements #82

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ android:
     - build-tools-25.0.3
     - android-25
     - extra-android-m2repository
+script:
+  - ./gradlew build check jacocoTestReport
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/dmfs/ContentPal.svg?branch=master)](https://travis-ci.org/dmfs/ContentPal)
+[![codecov](https://codecov.io/gh/dmfs/ContentPal/branch/master/graph/badge.svg)](https://codecov.io/gh/dmfs/ContentPal)
 
 # ContentPal
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
+        classpath 'org.jacoco:org.jacoco.core:0.7.9'
     }
 }
 

--- a/calendarpal/build.gradle
+++ b/calendarpal/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion 25
@@ -16,6 +17,13 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
         }
     }
     packagingOptions {

--- a/contactspal/build.gradle
+++ b/contactspal/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion 25
@@ -16,6 +17,13 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
         }
     }
     packagingOptions {

--- a/contentpal-testing/build.gradle
+++ b/contentpal-testing/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion 25
@@ -10,7 +11,13 @@ android {
         versionCode 1
         versionName "1.0"
     }
-
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
+        }
+    }
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES.txt'
         exclude 'META-INF/LICENSE.txt'

--- a/contentpal/build.gradle
+++ b/contentpal/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion 25
@@ -16,6 +17,13 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
         }
     }
     packagingOptions {

--- a/contenttestpal/build.gradle
+++ b/contenttestpal/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'jacoco-android'
 
 android {
     compileSdkVersion 25

--- a/contenttestpal/build.gradle
+++ b/contenttestpal/build.gradle
@@ -11,7 +11,13 @@ android {
         versionCode 1
         versionName "1.0"
     }
-
+    testOptions {
+        unitTests.all {
+            jacoco {
+                includeNoLocationClasses = true
+            }
+        }
+    }
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES.txt'
         exclude 'META-INF/LICENSE.txt'


### PR DESCRIPTION
This commit does essentially two things:

* Integrate jacoco-android-gradle-plugin to add a task to create JaCoCo reports
* update .travis.yml to create JaCoCo reports and upload them to codecov.io

The reports can be seen at https://codecov.io/gh/dmfs/ContentPal
I'm not sure if codecov.io posts any reports to the PR like it did in the carrot project. That might require additional configuration. We'll see.