### PR TITLE
Add missing OperationBatch tests. #88

### DIFF
--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/rowset/TestRowSet.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/rowset/TestRowSet.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.rowset;
+
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.ClosableIterator;
+import org.dmfs.android.contentpal.RowSet;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.testing.tools.FakeClosable;
+import org.dmfs.iterables.ArrayIterable;
+
+
+/**
+ * {@link RowSet} that simply delegates to the provided {@link RowSnapshot}s.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class TestRowSet<T> implements RowSet<T>
+{
+    private final Iterable<RowSnapshot<T>> mDelegate;
+
+
+    public TestRowSet(Iterable<RowSnapshot<T>> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @SafeVarargs
+    public TestRowSet(RowSnapshot<T>... rowSnapshots)
+    {
+        this(new ArrayIterable<>(rowSnapshots));
+    }
+
+
+    @NonNull
+    @Override
+    public ClosableIterator<RowSnapshot<T>> iterator()
+    {
+        return new FakeClosable<>(mDelegate.iterator());
+    }
+}

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/table/Contract.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/table/Contract.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.table;
+
+import org.dmfs.android.contentpal.Table;
+
+
+/**
+ * Type that can be used in tests for the generic parameter of {@link Table}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Contract
+{
+    private Contract()
+    {
+
+    }
+}

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/tools/FakeClosable.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/tools/FakeClosable.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.tools;
+
+import org.dmfs.android.contentpal.ClosableIterator;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+
+/**
+ * An adapter which makes any {@link Iterator} a {@link ClosableIterator}.
+ *
+ * @author Marten Gajda
+ */
+public final class FakeClosable<T> implements ClosableIterator<T>
+{
+    private final Iterator<T> mDelegate;
+
+
+    public FakeClosable(Iterator<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public void close() throws IOException
+    {
+        // nothing to do
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return mDelegate.hasNext();
+    }
+
+
+    @Override
+    public T next()
+    {
+        return mDelegate.next();
+    }
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/DelegatingOperationsBatchTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/DelegatingOperationsBatchTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.batches;
+
+import org.dmfs.android.contentpal.Operation;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link DelegatingOperationsBatch}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public class DelegatingOperationsBatchTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        Iterable<Operation<?>> mockIterable = failingMock(Iterable.class);
+        Iterator<Operation<?>> dummyIterator = dummy(Iterator.class);
+        doReturn(dummyIterator).when(mockIterable).iterator();
+
+        assertThat(new TestDelegatingOperationsBatch(mockIterable).iterator(), sameInstance(dummyIterator));
+    }
+
+
+    private static final class TestDelegatingOperationsBatch extends DelegatingOperationsBatch
+    {
+
+        private TestDelegatingOperationsBatch(Iterable<Operation<?>> iterableDelegate)
+        {
+            super(iterableDelegate);
+        }
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/JoinedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/JoinedTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.batches;
+
+import org.dmfs.android.contentpal.Operation;
+import org.junit.Test;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link Joined}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public class JoinedTest
+{
+
+    @Test
+    public void testSingle()
+    {
+        Operation<?> dummyOperation = dummy(Operation.class);
+        assertThat(new Joined(new SingletonBatch(dummyOperation)), contains(new Operation<?>[] { dummyOperation }));
+    }
+
+
+    @Test
+    public void testMultiSingle()
+    {
+        Operation<?> dummyOperation1 = dummy(Operation.class);
+        Operation<?> dummyOperation2 = dummy(Operation.class);
+        Operation<?> dummyOperation3 = dummy(Operation.class);
+
+        assertThat(new Joined(new SingletonBatch(dummyOperation1), new SingletonBatch(dummyOperation2), new SingletonBatch(dummyOperation3)),
+                contains(dummyOperation1, dummyOperation2, dummyOperation3));
+    }
+
+
+    @Test
+    public void testMulti()
+    {
+        Operation<?> dummyOperation1 = dummy(Operation.class);
+        Operation<?> dummyOperation2 = dummy(Operation.class);
+        Operation<?> dummyOperation3 = dummy(Operation.class);
+
+        assertThat(new Joined(new MultiBatch(dummyOperation1, dummyOperation2, dummyOperation3)),
+                contains(dummyOperation1, dummyOperation2, dummyOperation3));
+    }
+
+
+    @Test
+    public void testMultiMulti()
+    {
+        Operation<?> dummyOperation1 = dummy(Operation.class);
+        Operation<?> dummyOperation2 = dummy(Operation.class);
+        Operation<?> dummyOperation3 = dummy(Operation.class);
+
+        Operation<?> dummyOperationA = dummy(Operation.class);
+        Operation<?> dummyOperationB = dummy(Operation.class);
+        Operation<?> dummyOperationC = dummy(Operation.class);
+
+        assertThat(new Joined(new MultiBatch(dummyOperation1, dummyOperation2, dummyOperation3),
+                        new MultiBatch(dummyOperationA, dummyOperationB, dummyOperationC)),
+                contains(dummyOperation1, dummyOperation2, dummyOperation3, dummyOperationA, dummyOperationB, dummyOperationC));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MappedRowSetBatchTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MappedRowSetBatchTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.batches;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.RowSet;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.testing.rowset.TestRowSet;
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.dmfs.iterators.Function;
+import org.junit.Test;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Test for {@link MappedRowSetBatch}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class MappedRowSetBatchTest
+{
+
+    @Test
+    public void test()
+    {
+        RowSnapshot<Contract> dummyRowSnapshot1 = dummy(RowSnapshot.class);
+        RowSnapshot<Contract> dummyRowSnapshot2 = dummy(RowSnapshot.class);
+        RowSnapshot<Contract> dummyRowSnapshot3 = dummy(RowSnapshot.class);
+        RowSet<Contract> rowSet = new TestRowSet<>(dummyRowSnapshot1, dummyRowSnapshot2, dummyRowSnapshot3);
+
+        Operation<?> dummyOperation1 = dummy(Operation.class);
+        Operation<?> dummyOperation2 = dummy(Operation.class);
+        Operation<?> dummyOperation3 = dummy(Operation.class);
+
+        Function<RowSnapshot<Contract>, Operation<?>> mockFunction = failingMock(Function.class);
+        doReturn(dummyOperation1).when(mockFunction).apply(dummyRowSnapshot1);
+        doReturn(dummyOperation2).when(mockFunction).apply(dummyRowSnapshot2);
+        doReturn(dummyOperation3).when(mockFunction).apply(dummyRowSnapshot3);
+
+        assertThat(new MappedRowSetBatch<>(rowSet, mockFunction), contains(dummyOperation1, dummyOperation2, dummyOperation3));
+    }
+
+}


### PR DESCRIPTION
This contains the missing tests for the `batches` package. This alone will not resolve #88 (50%) coverage, I plan to submit additional pull requests for other packages.

This is NOT ready for review at the moment,  it is pending on `MockFunction` and `IterableMatchers` from jems:test-utils, I am just submitting it so I can put it aside safely for that time. The branch is also based on #110 currently.
These tests could be finalized without `MockFunction` and `IterableMatchers` as well, just with more verbose tests, @dmfs let me know if you would prefer that at this point.

