### PR TITLE
Add missing unit tests for contentpal operations package. #88

### DIFF
--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkDelete.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkDelete.java
@@ -49,8 +49,8 @@ public final class BulkDelete<T> implements Operation<T>
 
     public BulkDelete(@NonNull Table<T> table, @NonNull Predicate predicate)
     {
-        this.mTable = table;
-        this.mPredicate = predicate;
+        mTable = table;
+        mPredicate = predicate;
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AssertTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.assertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link Assert}.
+ *
+ * @author Gabor Keszthelyi
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public final class AssertTest
+{
+
+    @Test
+    public void testReference() throws Exception
+    {
+        assertThat(new Assert<Object>(dummy(RowSnapshot.class), dummy(RowData.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+    }
+
+
+    @Test
+    public void testContentOperationBuilder() throws Exception
+    {
+        RowSnapshot<Object> mockRowSnapshot = failingMock(RowSnapshot.class);
+        SoftRowReference<Object> dummyRowReference = dummy(SoftRowReference.class);
+        doReturn(dummyRowReference).when(mockRowSnapshot).reference();
+        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(dummyRowReference).assertOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new Assert<>(mockRowSnapshot, new CharSequenceRowData<>("key", "value")),
+                builds(
+                        assertOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withValuesOnly(
+                                containing("key", "value"))));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.assertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.android.contentpal.testing.predicates.PredicateSelectionMatcher.predicateWithSelection;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link BulkAssert}.
+ *
+ * @author Gabor Keszthelyi
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public final class BulkAssertTest
+{
+
+    @Test
+    public void testReference()
+    {
+        assertThat(new BulkAssert<Object>(dummy(Table.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+
+        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(Predicate.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+
+        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(RowData.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+
+        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(RowData.class), dummy(Predicate.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Operation<Object> mockAssertOperation = failingMock(Operation.class);
+
+        doReturn(mockAssertOperation).when(mockTable).assertOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
+
+        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkAssert<>(mockTable),
+                builds(
+                        assertOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withoutValues()));
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table_predicate()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Predicate dummyPredicate = dummy(Predicate.class);
+        Operation<Object> mockAssertOperation = failingMock(Operation.class);
+
+        doReturn(mockAssertOperation).when(mockTable).assertOperation(EmptyUriParams.INSTANCE, dummyPredicate);
+
+        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkAssert<>(mockTable, dummyPredicate),
+                builds(
+                        assertOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withoutValues()));
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table_data()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Operation<Object> mockAssertOperation = failingMock(Operation.class);
+
+        doReturn(mockAssertOperation).when(mockTable).assertOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
+
+        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkAssert<>(mockTable, new CharSequenceRowData<>("key", "value")),
+                builds(
+                        assertOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withValuesOnly(
+                                containing("key", "value"))));
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table_data_predicate()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Predicate dummyPredicate = dummy(Predicate.class);
+        Operation<Object> mockAssertOperation = failingMock(Operation.class);
+
+        doReturn(mockAssertOperation).when(mockTable).assertOperation(EmptyUriParams.INSTANCE, dummyPredicate);
+
+        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkAssert<>(mockTable, new CharSequenceRowData<>("key", "value"), dummyPredicate),
+                builds(
+                        assertOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withValuesOnly(
+                                containing("key", "value"))));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.deleteOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
+import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.android.contentpal.testing.predicates.PredicateSelectionMatcher.predicateWithSelection;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+
+/**
+ * Unit test for {@link BulkDelete}.
+ *
+ * @author Gabor Keszthelyi
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public final class BulkDeleteTest
+{
+
+    @Test
+    public void testReference()
+    {
+        assertThat(new BulkDelete<Object>(dummy(Table.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+
+        assertThat(new BulkDelete<Object>(dummy(Table.class), dummy(Predicate.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Operation<Object> mockOperation = failingMock(Operation.class);
+
+        doReturn(mockOperation).when(mockTable).deleteOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
+
+        doReturn(ContentProviderOperation.newDelete(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkDelete<>(mockTable),
+                builds(
+                        deleteOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withoutValues()));
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table_predicate()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Operation<Object> mockOperation = failingMock(Operation.class);
+        Predicate dummyPredicate = mock(Predicate.class);
+
+        doReturn(mockOperation).when(mockTable).deleteOperation(EmptyUriParams.INSTANCE, dummyPredicate);
+
+        doReturn(ContentProviderOperation.newDelete(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkDelete<>(mockTable, dummyPredicate),
+                builds(
+                        deleteOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withoutValues()));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.Table;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.updateOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.android.contentpal.testing.predicates.PredicateSelectionMatcher.predicateWithSelection;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link BulkUpdate}.
+ *
+ * @author Gabor Keszthelyi
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public final class BulkUpdateTest
+{
+
+    @Test
+    public void testReference()
+    {
+        assertThat(new BulkUpdate<Object>(dummy(Table.class), dummy(RowData.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+
+        assertThat(new BulkUpdate<Object>(dummy(Table.class), dummy(RowData.class), dummy(Predicate.class)).reference(),
+                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table_data()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Operation<Object> mockOperation = failingMock(Operation.class);
+
+        doReturn(mockOperation).when(mockTable).updateOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
+
+        doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkUpdate<>(mockTable, new CharSequenceRowData<>("key", "value")),
+                builds(
+                        updateOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withValuesOnly(
+                                containing("key", "value"))));
+    }
+
+
+    @Test
+    public void testContentOperationBuilder_ctor_table_data_predicate()
+    {
+        Table<Object> mockTable = failingMock(Table.class);
+        Predicate dummyPredicate = dummy(Predicate.class);
+        Operation<Object> mockOperation = failingMock(Operation.class);
+
+        doReturn(mockOperation).when(mockTable).updateOperation(EmptyUriParams.INSTANCE, dummyPredicate);
+
+        doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+
+        assertThat(new BulkUpdate<>(mockTable, new CharSequenceRowData<>("key", "value"), dummyPredicate),
+                builds(
+                        updateOperation(),
+                        withoutExpectedCount(),
+                        withYieldNotAllowed(),
+                        withValuesOnly(
+                                containing("key", "value"))));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DelegatingOperationTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DelegatingOperationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.operations;
+
+import android.content.ContentProviderOperation;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.SoftRowReference;
+import org.dmfs.android.contentpal.TransactionContext;
+import org.dmfs.optional.Optional;
+import org.junit.Test;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link DelegatingOperation}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class DelegatingOperationTest
+{
+
+    @Test
+    public void test()
+    {
+        Operation<Object> mockDelegate = failingMock(Operation.class);
+        Optional<SoftRowReference<Object>> dummyRowReference = dummy(Optional.class);
+        ContentProviderOperation.Builder dummyBuilder = dummy(ContentProviderOperation.Builder.class);
+        TransactionContext dummyTContext = dummy(TransactionContext.class);
+
+        doReturn(dummyRowReference).when(mockDelegate).reference();
+        doReturn(dummyBuilder).when(mockDelegate).contentOperationBuilder(dummyTContext);
+
+        assertThat(new TestDelegatingOperation<>(mockDelegate).reference(), sameInstance(dummyRowReference));
+        assertThat(new TestDelegatingOperation<>(mockDelegate).contentOperationBuilder(dummyTContext), sameInstance(dummyBuilder));
+    }
+
+
+    private static final class TestDelegatingOperation<T> extends DelegatingOperation<T>
+    {
+
+        private TestDelegatingOperation(Operation<T> delegate)
+        {
+            super(delegate);
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request adds the missing unit tests for the contentpal operations package classes.

Branch is based on #110-#111 currently.