### PR TITLE
Introduce dedicated Projection type. Implements #134

### DIFF
--- a/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
+++ b/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
@@ -75,6 +75,7 @@ import org.dmfs.android.contactspal.data.relation.RelationData;
 import org.dmfs.android.contactspal.data.sip.SipAddressData;
 import org.dmfs.android.contactspal.operations.RawContactData;
 import org.dmfs.android.contactspal.operations.TransientRawContactCleanup;
+import org.dmfs.android.contactspal.projections.RawContactsProjection;
 import org.dmfs.android.contactspal.rowsets.Unsynced;
 import org.dmfs.android.contactspal.tables.Local;
 import org.dmfs.android.contactspal.tables.RawContacts;
@@ -231,7 +232,7 @@ public class DemoActivity extends AppCompatActivity
         {
             return;
         }
-        for (RowSnapshot<ContactsContract.RawContacts> row : new Unsynced(mRawContacts.view(mContactsClient)))
+        for (RowSnapshot<ContactsContract.RawContacts> row : new Unsynced(mRawContacts.view(mContactsClient), new RawContactsProjection()))
         {
             Log.v("ContentPal Demo", "---- Raw Contact ----");
             RowDataSnapshot<?> values = row.values();

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/projections/AttendeesProjection.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/projections/AttendeesProjection.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.projections;
+
+import android.provider.CalendarContract;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.android.contentpal.projections.DelegatingProjection;
+import org.dmfs.android.contentpal.projections.MultiProjection;
+
+
+/**
+ * A {@link Projection} of all {@link CalendarContract.Attendees} columns.
+ *
+ * @author Marten Gajda
+ */
+public final class AttendeesProjection extends DelegatingProjection<CalendarContract.Attendees>
+{
+    public AttendeesProjection()
+    {
+        super(new MultiProjection<CalendarContract.Attendees>(
+                CalendarContract.Attendees._ID,
+                CalendarContract.Attendees.ATTENDEE_EMAIL,
+                CalendarContract.Attendees.ATTENDEE_NAME,
+                CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
+                CalendarContract.Attendees.ATTENDEE_STATUS,
+                CalendarContract.Attendees.ATTENDEE_TYPE));
+    }
+}

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/tables/CalendarScoped.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/tables/CalendarScoped.java
@@ -34,7 +34,7 @@ import org.dmfs.android.contentpal.View;
  * A view onto the {@link CalendarContract.Events} table which contains only events of a specific calendar. Events created with {@link
  * #insertOperation(UriParams)} will automatically be added to this calendar.
  * <p>
- * Note, if you create a {@link View} (using {@link #view(ContentProviderClient, String...)}) with a virtual {@link RowSnapshot}, the {@link View} will always
+ * Note, if you create a {@link View} (using {@link Table#view(ContentProviderClient)}) with a virtual {@link RowSnapshot}, the {@link View} will always
  * be empty, even after adding and committing rows.
  *
  * @author Marten Gajda
@@ -92,9 +92,9 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
 
     @NonNull
     @Override
-    public View<CalendarContract.Events> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public View<CalendarContract.Events> view(@NonNull ContentProviderClient client)
     {
-        return new org.dmfs.android.calendarpal.views.CalendarScoped(mCalendarRow, mDelegate.view(client, projection));
+        return new org.dmfs.android.calendarpal.views.CalendarScoped(mCalendarRow, mDelegate.view(client));
     }
 
 

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Attendees.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Attendees.java
@@ -33,17 +33,6 @@ public final class Attendees extends DelegatingView<CalendarContract.Attendees>
 {
     public Attendees(@NonNull ContentProviderClient client)
     {
-        this(client, CalendarContract.Attendees._ID,
-                CalendarContract.Attendees.ATTENDEE_EMAIL,
-                CalendarContract.Attendees.ATTENDEE_NAME,
-                CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
-                CalendarContract.Attendees.ATTENDEE_STATUS,
-                CalendarContract.Attendees.ATTENDEE_TYPE);
-    }
-
-
-    public Attendees(@NonNull ContentProviderClient client, @NonNull String... projection)
-    {
-        super(new BaseView<CalendarContract.Attendees>(client, CalendarContract.Attendees.CONTENT_URI, projection));
+        super(new BaseView<CalendarContract.Attendees>(client, CalendarContract.Attendees.CONTENT_URI));
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/CalendarScoped.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/CalendarScoped.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
@@ -51,12 +52,10 @@ public final class CalendarScoped implements View<CalendarContract.Events>
      *         A {@link ContentProviderClient}
      * @param calendarRow
      *         The {@link RowSnapshot} of the calendar.
-     * @param projection
-     *         The columns of the projection.
      */
-    public CalendarScoped(@NonNull ContentProviderClient client, @NonNull RowSnapshot<CalendarContract.Calendars> calendarRow, @NonNull String... projection)
+    public CalendarScoped(@NonNull ContentProviderClient client, @NonNull RowSnapshot<CalendarContract.Calendars> calendarRow)
     {
-        this(calendarRow, new Events(client, projection));
+        this(calendarRow, new Events(client));
     }
 
 
@@ -69,12 +68,12 @@ public final class CalendarScoped implements View<CalendarContract.Events>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<CalendarContract.Events> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(
                 uriParams,
-                new org.dmfs.android.calendarpal.predicates.CalendarScoped(mCalendarRow, predicate),
-                sorting);
+                projection,
+                new org.dmfs.android.calendarpal.predicates.CalendarScoped(mCalendarRow, predicate), sorting);
     }
 
 
@@ -83,13 +82,5 @@ public final class CalendarScoped implements View<CalendarContract.Events>
     public Table<CalendarContract.Events> table()
     {
         return new org.dmfs.android.calendarpal.tables.CalendarScoped(mCalendarRow, mDelegate.table());
-    }
-
-
-    @NonNull
-    @Override
-    public View<CalendarContract.Events> withProjection(@NonNull String... projection)
-    {
-        return new CalendarScoped(mCalendarRow, mDelegate.withProjection(projection));
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Calendars.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Calendars.java
@@ -31,8 +31,8 @@ import org.dmfs.android.contentpal.views.DelegatingView;
  */
 public final class Calendars extends DelegatingView<CalendarContract.Calendars>
 {
-    public Calendars(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public Calendars(@NonNull ContentProviderClient client)
     {
-        super(new BaseView<CalendarContract.Calendars>(client, CalendarContract.Calendars.CONTENT_URI, projection));
+        super(new BaseView<CalendarContract.Calendars>(client, CalendarContract.Calendars.CONTENT_URI));
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Events.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Events.java
@@ -31,8 +31,8 @@ import org.dmfs.android.contentpal.views.DelegatingView;
  */
 public final class Events extends DelegatingView<CalendarContract.Events>
 {
-    public Events(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public Events(@NonNull ContentProviderClient client)
     {
-        super(new BaseView<CalendarContract.Events>(client, CalendarContract.Events.CONTENT_URI, projection));
+        super(new BaseView<CalendarContract.Events>(client, CalendarContract.Events.CONTENT_URI));
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Reminders.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/Reminders.java
@@ -33,15 +33,6 @@ public final class Reminders extends DelegatingView<CalendarContract.Reminders>
 {
     public Reminders(@NonNull ContentProviderClient client)
     {
-        this(client, CalendarContract.Reminders._ID,
-                CalendarContract.Reminders.MINUTES,
-                CalendarContract.Reminders.METHOD,
-                CalendarContract.Reminders.EVENT_ID);
-    }
-
-
-    public Reminders(@NonNull ContentProviderClient client, @NonNull String... projection)
-    {
-        super(new BaseView<CalendarContract.Reminders>(client, CalendarContract.Reminders.CONTENT_URI, projection));
+        super(new BaseView<CalendarContract.Reminders>(client, CalendarContract.Reminders.CONTENT_URI));
     }
 }

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/projections/AttendeesProjectionTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/projections/AttendeesProjectionTest.java
@@ -18,8 +18,6 @@ package org.dmfs.android.calendarpal.projections;
 
 import android.provider.CalendarContract;
 
-import org.dmfs.android.calendarpal.projections.AttendeesProjection;
-import org.dmfs.iterables.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
@@ -37,11 +35,11 @@ public class AttendeesProjectionTest
     {
         assertThat(new AttendeesProjection(),
                 projects(
-                        new Seq<>(CalendarContract.Attendees._ID,
-                                CalendarContract.Attendees.ATTENDEE_EMAIL,
-                                CalendarContract.Attendees.ATTENDEE_NAME,
-                                CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
-                                CalendarContract.Attendees.ATTENDEE_STATUS,
-                                CalendarContract.Attendees.ATTENDEE_TYPE)));
+                        CalendarContract.Attendees._ID,
+                        CalendarContract.Attendees.ATTENDEE_EMAIL,
+                        CalendarContract.Attendees.ATTENDEE_NAME,
+                        CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
+                        CalendarContract.Attendees.ATTENDEE_STATUS,
+                        CalendarContract.Attendees.ATTENDEE_TYPE));
     }
 }

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/projections/AttendeesProjectionTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/projections/AttendeesProjectionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.projections;
+
+import android.provider.CalendarContract;
+
+import org.dmfs.android.calendarpal.projections.AttendeesProjection;
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class AttendeesProjectionTest
+{
+
+    @Test
+    public void test()
+    {
+        assertThat(new AttendeesProjection(),
+                projects(
+                        new Seq<>(CalendarContract.Attendees._ID,
+                                CalendarContract.Attendees.ATTENDEE_EMAIL,
+                                CalendarContract.Attendees.ATTENDEE_NAME,
+                                CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
+                                CalendarContract.Attendees.ATTENDEE_STATUS,
+                                CalendarContract.Attendees.ATTENDEE_TYPE)));
+    }
+}

--- a/contactspal/build.gradle
+++ b/contactspal/build.gradle
@@ -48,4 +48,5 @@ dependencies {
     testImplementation 'junit:junit:' + JUNIT_VERSION
     testImplementation 'org.mockito:mockito-core:' + MOCKITO_VERSION
     testImplementation 'org.robolectric:robolectric:' + ROBOLECTRIC_VERSION
+    testImplementation project(':contentpal-testing')
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/projections/DataProjection.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/projections/DataProjection.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.projections;
+
+import android.provider.ContactsContract;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.android.contentpal.projections.DelegatingProjection;
+import org.dmfs.android.contentpal.projections.MultiProjection;
+
+
+/**
+ * A {@link Projection} of all {@link ContactsContract.Data} columns which are present since API level 11.
+ * <p>
+ * Note, this doesn't include any joined columns from {@link ContactsContract.RawContacts}.
+ *
+ * @author Marten Gajda
+ */
+public final class DataProjection extends DelegatingProjection<ContactsContract.Data>
+{
+    public DataProjection()
+    {
+        // TODO: it's probably better to compose this from smaller projections with just a few columns
+        super(new MultiProjection<ContactsContract.Data>(
+                ContactsContract.Data._ID,
+                ContactsContract.Data.MIMETYPE,
+                ContactsContract.Data.RAW_CONTACT_ID,
+                ContactsContract.Data.IS_PRIMARY,
+                ContactsContract.Data.IS_SUPER_PRIMARY,
+                ContactsContract.Data.DATA_VERSION,
+                ContactsContract.Data.IS_READ_ONLY,
+                ContactsContract.Data.DATA1,
+                ContactsContract.Data.DATA2,
+                ContactsContract.Data.DATA3,
+                ContactsContract.Data.DATA4,
+                ContactsContract.Data.DATA5,
+                ContactsContract.Data.DATA6,
+                ContactsContract.Data.DATA7,
+                ContactsContract.Data.DATA8,
+                ContactsContract.Data.DATA9,
+                ContactsContract.Data.DATA10,
+                ContactsContract.Data.DATA11,
+                ContactsContract.Data.DATA12,
+                ContactsContract.Data.DATA13,
+                ContactsContract.Data.DATA14,
+                ContactsContract.Data.DATA15,
+                ContactsContract.Data.SYNC1,
+                ContactsContract.Data.SYNC2,
+                ContactsContract.Data.SYNC3,
+                ContactsContract.Data.SYNC4));
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/projections/RawContactsProjection.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/projections/RawContactsProjection.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.projections;
+
+import android.provider.ContactsContract;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.android.contentpal.projections.DelegatingProjection;
+import org.dmfs.android.contentpal.projections.MultiProjection;
+
+
+/**
+ * A {@link Projection} of all {@link ContactsContract.RawContacts} columns which are present since API level 11.
+ *
+ * @author Marten Gajda
+ */
+public final class RawContactsProjection extends DelegatingProjection<ContactsContract.RawContacts>
+{
+    public RawContactsProjection()
+    {
+        // TODO: it's probably better to compose this from smaller projections with just a few columns
+        super(new MultiProjection<ContactsContract.RawContacts>(
+                ContactsContract.RawContacts._ID,
+                ContactsContract.RawContacts.CONTACT_ID,
+                ContactsContract.RawContacts.AGGREGATION_MODE,
+                ContactsContract.RawContacts.DELETED,
+                // the following column doesn't seem to work on Android 7.1
+                //ContactsContract.RawContacts.RAW_CONTACT_IS_READ_ONLY,
+
+                // values from ContactNameColumns
+                ContactsContract.RawContacts.DISPLAY_NAME_SOURCE,
+                ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY,
+                ContactsContract.RawContacts.DISPLAY_NAME_ALTERNATIVE,
+                ContactsContract.RawContacts.PHONETIC_NAME_STYLE,
+                ContactsContract.RawContacts.PHONETIC_NAME,
+                ContactsContract.RawContacts.SORT_KEY_PRIMARY,
+                ContactsContract.RawContacts.SORT_KEY_ALTERNATIVE,
+
+                // values from SyncColumns
+                ContactsContract.RawContacts.ACCOUNT_NAME,
+                ContactsContract.RawContacts.ACCOUNT_TYPE,
+                ContactsContract.RawContacts.DIRTY,
+                ContactsContract.RawContacts.SOURCE_ID,
+                ContactsContract.RawContacts.VERSION));
+    }
+}

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Dirty.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Dirty.java
@@ -20,6 +20,7 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contactspal.tables.RawContacts;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.predicates.AnyOf;
@@ -35,9 +36,10 @@ import org.dmfs.android.contentpal.rowsets.QueryRowSet;
  */
 public final class Dirty extends DelegatingRowSet<ContactsContract.RawContacts>
 {
-    public Dirty(@NonNull View<ContactsContract.RawContacts> mRawContacts)
+    public Dirty(@NonNull View<ContactsContract.RawContacts> mRawContacts, @NonNull Projection<ContactsContract.RawContacts> projection)
     {
         super(new QueryRowSet<>(mRawContacts,
+                projection,
                 new AnyOf(
                         new EqArg(ContactsContract.RawContacts.DIRTY, 1),
                         new EqArg(ContactsContract.RawContacts.DELETED, 1))));

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/RawContactDataRows.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/RawContactDataRows.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contactspal.tables.Data;
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowReference;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.RowSnapshot;
@@ -52,9 +53,9 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      * @param rawContact
      *         The {@link RowSnapshot} of a RawContact.
      */
-    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact)
+    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact)
     {
-        this(dataView, rawContact, new AnyOf());
+        this(dataView, projection, rawContact, new AnyOf());
     }
 
 
@@ -66,9 +67,9 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      * @param rawContact
      *         The {@link RowReference} of a RawContact.
      */
-    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull RowReference<ContactsContract.RawContacts> rawContact)
+    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowReference<ContactsContract.RawContacts> rawContact)
     {
-        this(dataView, rawContact, new AnyOf());
+        this(dataView, projection, rawContact, new AnyOf());
     }
 
 
@@ -82,9 +83,9 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      * @param predicate
      *         A {@link Predicate} to filter the data rows to return.
      */
-    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact, @NonNull Predicate predicate)
+    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact, @NonNull Predicate predicate)
     {
-        this(dataView, new RowSnapshotReference<>(rawContact), predicate);
+        this(dataView, projection, new RowSnapshotReference<>(rawContact), predicate);
     }
 
 
@@ -98,15 +99,15 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      * @param predicate
      *         A {@link Predicate} to filter the data rows to return.
      */
-    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull RowReference<ContactsContract.RawContacts> rawContactReference, @NonNull Predicate predicate)
+    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowReference<ContactsContract.RawContacts> rawContactReference, @NonNull Predicate predicate)
     {
-        this(dataView, new AllOf(new ReferringTo<>(BaseColumns._ID, rawContactReference), predicate));
+        this(dataView, projection, new AllOf(new ReferringTo<>(BaseColumns._ID, rawContactReference), predicate));
     }
 
 
-    private RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Predicate predicate)
+    private RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull Predicate predicate)
     {
-        super(new QueryRowSet<>(dataView, predicate));
+        super(new QueryRowSet<>(dataView, projection, predicate));
     }
 
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Unsynced.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Unsynced.java
@@ -19,6 +19,7 @@ package org.dmfs.android.contactspal.rowsets;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.predicates.IsNull;
@@ -34,9 +35,9 @@ import org.dmfs.android.contentpal.rowsets.QueryRowSet;
 public final class Unsynced extends DelegatingRowSet<ContactsContract.RawContacts>
 {
 
-    public Unsynced(@NonNull View<ContactsContract.RawContacts> mRawContacts)
+    public Unsynced(@NonNull View<ContactsContract.RawContacts> mRawContacts, @NonNull Projection<ContactsContract.RawContacts> projection)
     {
-        super(new QueryRowSet<>(mRawContacts, new IsNull(ContactsContract.RawContacts.SOURCE_ID)));
+        super(new QueryRowSet<>(mRawContacts, projection, new IsNull(ContactsContract.RawContacts.SOURCE_ID)));
     }
 
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
@@ -81,8 +81,8 @@ public final class AggregationExceptions implements Table<ContactsContract.Aggre
 
     @NonNull
     @Override
-    public View<ContactsContract.AggregationExceptions> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public View<ContactsContract.AggregationExceptions> view(@NonNull ContentProviderClient client)
     {
-        return mDelegate.view(client, projection);
+        return mDelegate.view(client);
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
@@ -85,9 +85,9 @@ public final class Local implements Table<ContactsContract.RawContacts>
 
     @NonNull
     @Override
-    public View<ContactsContract.RawContacts> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public View<ContactsContract.RawContacts> view(@NonNull ContentProviderClient client)
     {
-        return new org.dmfs.android.contactspal.views.Local(mDelegate.view(client, projection));
+        return new org.dmfs.android.contactspal.views.Local(mDelegate.view(client));
     }
 
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/views/Data.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/views/Data.java
@@ -31,8 +31,8 @@ import org.dmfs.android.contentpal.views.DelegatingView;
  */
 public final class Data extends DelegatingView<ContactsContract.Data>
 {
-    public Data(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public Data(@NonNull ContentProviderClient client)
     {
-        super(new BaseView<ContactsContract.Data>(client, ContactsContract.Data.CONTENT_URI, projection));
+        super(new BaseView<ContactsContract.Data>(client, ContactsContract.Data.CONTENT_URI));
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/views/Local.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/views/Local.java
@@ -22,6 +22,7 @@ import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
@@ -52,11 +53,11 @@ public final class Local implements View<ContactsContract.RawContacts>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<ContactsContract.RawContacts> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(uriParams,
-                new AllOf(predicate, new IsNull(ContactsContract.RawContacts.ACCOUNT_NAME), new IsNull(ContactsContract.RawContacts.ACCOUNT_TYPE)),
-                sorting);
+                projection,
+                new AllOf(predicate, new IsNull(ContactsContract.RawContacts.ACCOUNT_NAME), new IsNull(ContactsContract.RawContacts.ACCOUNT_TYPE)), sorting);
     }
 
 
@@ -65,13 +66,5 @@ public final class Local implements View<ContactsContract.RawContacts>
     public Table<ContactsContract.RawContacts> table()
     {
         return new org.dmfs.android.contactspal.tables.Local(mDelegate.table());
-    }
-
-
-    @NonNull
-    @Override
-    public View<ContactsContract.RawContacts> withProjection(@NonNull String... projection)
-    {
-        return new Local(mDelegate.withProjection(projection));
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/views/RawContacts.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/views/RawContacts.java
@@ -31,8 +31,8 @@ import org.dmfs.android.contentpal.views.DelegatingView;
  */
 public final class RawContacts extends DelegatingView<ContactsContract.RawContacts>
 {
-    public RawContacts(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public RawContacts(@NonNull ContentProviderClient client)
     {
-        super(new BaseView<ContactsContract.RawContacts>(client, ContactsContract.RawContacts.CONTENT_URI, projection));
+        super(new BaseView<ContactsContract.RawContacts>(client, ContactsContract.RawContacts.CONTENT_URI));
     }
 }

--- a/contactspal/src/test/java/org/dmfs/android/contactspal/projections/DataProjectionTest.java
+++ b/contactspal/src/test/java/org/dmfs/android/contactspal/projections/DataProjectionTest.java
@@ -18,7 +18,6 @@ package org.dmfs.android.contactspal.projections;
 
 import android.provider.ContactsContract;
 
-import org.dmfs.iterables.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
@@ -33,33 +32,34 @@ public class DataProjectionTest
     @Test
     public void test() throws Exception
     {
-        assertThat(new DataProjection(), projects(new Seq<>(
-                ContactsContract.Data._ID,
-                ContactsContract.Data.MIMETYPE,
-                ContactsContract.Data.RAW_CONTACT_ID,
-                ContactsContract.Data.IS_PRIMARY,
-                ContactsContract.Data.IS_SUPER_PRIMARY,
-                ContactsContract.Data.DATA_VERSION,
-                ContactsContract.Data.IS_READ_ONLY,
-                ContactsContract.Data.DATA1,
-                ContactsContract.Data.DATA2,
-                ContactsContract.Data.DATA3,
-                ContactsContract.Data.DATA4,
-                ContactsContract.Data.DATA5,
-                ContactsContract.Data.DATA6,
-                ContactsContract.Data.DATA7,
-                ContactsContract.Data.DATA8,
-                ContactsContract.Data.DATA9,
-                ContactsContract.Data.DATA10,
-                ContactsContract.Data.DATA11,
-                ContactsContract.Data.DATA12,
-                ContactsContract.Data.DATA13,
-                ContactsContract.Data.DATA14,
-                ContactsContract.Data.DATA15,
-                ContactsContract.Data.SYNC1,
-                ContactsContract.Data.SYNC2,
-                ContactsContract.Data.SYNC3,
-                ContactsContract.Data.SYNC4)));
+        assertThat(new DataProjection(),
+                projects(
+                        ContactsContract.Data._ID,
+                        ContactsContract.Data.MIMETYPE,
+                        ContactsContract.Data.RAW_CONTACT_ID,
+                        ContactsContract.Data.IS_PRIMARY,
+                        ContactsContract.Data.IS_SUPER_PRIMARY,
+                        ContactsContract.Data.DATA_VERSION,
+                        ContactsContract.Data.IS_READ_ONLY,
+                        ContactsContract.Data.DATA1,
+                        ContactsContract.Data.DATA2,
+                        ContactsContract.Data.DATA3,
+                        ContactsContract.Data.DATA4,
+                        ContactsContract.Data.DATA5,
+                        ContactsContract.Data.DATA6,
+                        ContactsContract.Data.DATA7,
+                        ContactsContract.Data.DATA8,
+                        ContactsContract.Data.DATA9,
+                        ContactsContract.Data.DATA10,
+                        ContactsContract.Data.DATA11,
+                        ContactsContract.Data.DATA12,
+                        ContactsContract.Data.DATA13,
+                        ContactsContract.Data.DATA14,
+                        ContactsContract.Data.DATA15,
+                        ContactsContract.Data.SYNC1,
+                        ContactsContract.Data.SYNC2,
+                        ContactsContract.Data.SYNC3,
+                        ContactsContract.Data.SYNC4));
     }
 
 }

--- a/contactspal/src/test/java/org/dmfs/android/contactspal/projections/DataProjectionTest.java
+++ b/contactspal/src/test/java/org/dmfs/android/contactspal/projections/DataProjectionTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.projections;
+
+import android.provider.ContactsContract;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class DataProjectionTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new DataProjection(), projects(new Seq<>(
+                ContactsContract.Data._ID,
+                ContactsContract.Data.MIMETYPE,
+                ContactsContract.Data.RAW_CONTACT_ID,
+                ContactsContract.Data.IS_PRIMARY,
+                ContactsContract.Data.IS_SUPER_PRIMARY,
+                ContactsContract.Data.DATA_VERSION,
+                ContactsContract.Data.IS_READ_ONLY,
+                ContactsContract.Data.DATA1,
+                ContactsContract.Data.DATA2,
+                ContactsContract.Data.DATA3,
+                ContactsContract.Data.DATA4,
+                ContactsContract.Data.DATA5,
+                ContactsContract.Data.DATA6,
+                ContactsContract.Data.DATA7,
+                ContactsContract.Data.DATA8,
+                ContactsContract.Data.DATA9,
+                ContactsContract.Data.DATA10,
+                ContactsContract.Data.DATA11,
+                ContactsContract.Data.DATA12,
+                ContactsContract.Data.DATA13,
+                ContactsContract.Data.DATA14,
+                ContactsContract.Data.DATA15,
+                ContactsContract.Data.SYNC1,
+                ContactsContract.Data.SYNC2,
+                ContactsContract.Data.SYNC3,
+                ContactsContract.Data.SYNC4)));
+    }
+
+}

--- a/contactspal/src/test/java/org/dmfs/android/contactspal/projections/RawContactsProjectionTest.java
+++ b/contactspal/src/test/java/org/dmfs/android/contactspal/projections/RawContactsProjectionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contactspal.projections;
+
+import android.provider.ContactsContract;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class RawContactsProjectionTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new RawContactsProjection(), projects(new Seq<>(
+                ContactsContract.RawContacts._ID,
+                ContactsContract.RawContacts.CONTACT_ID,
+                ContactsContract.RawContacts.AGGREGATION_MODE,
+                ContactsContract.RawContacts.DELETED,
+                ContactsContract.RawContacts.DISPLAY_NAME_SOURCE,
+                ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY,
+                ContactsContract.RawContacts.DISPLAY_NAME_ALTERNATIVE,
+                ContactsContract.RawContacts.PHONETIC_NAME_STYLE,
+                ContactsContract.RawContacts.PHONETIC_NAME,
+                ContactsContract.RawContacts.SORT_KEY_PRIMARY,
+                ContactsContract.RawContacts.SORT_KEY_ALTERNATIVE,
+                ContactsContract.RawContacts.ACCOUNT_NAME,
+                ContactsContract.RawContacts.ACCOUNT_TYPE,
+                ContactsContract.RawContacts.DIRTY,
+                ContactsContract.RawContacts.SOURCE_ID,
+                ContactsContract.RawContacts.VERSION)));
+    }
+
+}

--- a/contactspal/src/test/java/org/dmfs/android/contactspal/projections/RawContactsProjectionTest.java
+++ b/contactspal/src/test/java/org/dmfs/android/contactspal/projections/RawContactsProjectionTest.java
@@ -18,7 +18,6 @@ package org.dmfs.android.contactspal.projections;
 
 import android.provider.ContactsContract;
 
-import org.dmfs.iterables.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
@@ -33,23 +32,24 @@ public class RawContactsProjectionTest
     @Test
     public void test() throws Exception
     {
-        assertThat(new RawContactsProjection(), projects(new Seq<>(
-                ContactsContract.RawContacts._ID,
-                ContactsContract.RawContacts.CONTACT_ID,
-                ContactsContract.RawContacts.AGGREGATION_MODE,
-                ContactsContract.RawContacts.DELETED,
-                ContactsContract.RawContacts.DISPLAY_NAME_SOURCE,
-                ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY,
-                ContactsContract.RawContacts.DISPLAY_NAME_ALTERNATIVE,
-                ContactsContract.RawContacts.PHONETIC_NAME_STYLE,
-                ContactsContract.RawContacts.PHONETIC_NAME,
-                ContactsContract.RawContacts.SORT_KEY_PRIMARY,
-                ContactsContract.RawContacts.SORT_KEY_ALTERNATIVE,
-                ContactsContract.RawContacts.ACCOUNT_NAME,
-                ContactsContract.RawContacts.ACCOUNT_TYPE,
-                ContactsContract.RawContacts.DIRTY,
-                ContactsContract.RawContacts.SOURCE_ID,
-                ContactsContract.RawContacts.VERSION)));
+        assertThat(new RawContactsProjection(),
+                projects(
+                        ContactsContract.RawContacts._ID,
+                        ContactsContract.RawContacts.CONTACT_ID,
+                        ContactsContract.RawContacts.AGGREGATION_MODE,
+                        ContactsContract.RawContacts.DELETED,
+                        ContactsContract.RawContacts.DISPLAY_NAME_SOURCE,
+                        ContactsContract.RawContacts.DISPLAY_NAME_PRIMARY,
+                        ContactsContract.RawContacts.DISPLAY_NAME_ALTERNATIVE,
+                        ContactsContract.RawContacts.PHONETIC_NAME_STYLE,
+                        ContactsContract.RawContacts.PHONETIC_NAME,
+                        ContactsContract.RawContacts.SORT_KEY_PRIMARY,
+                        ContactsContract.RawContacts.SORT_KEY_ALTERNATIVE,
+                        ContactsContract.RawContacts.ACCOUNT_NAME,
+                        ContactsContract.RawContacts.ACCOUNT_TYPE,
+                        ContactsContract.RawContacts.DIRTY,
+                        ContactsContract.RawContacts.SOURCE_ID,
+                        ContactsContract.RawContacts.VERSION));
     }
 
 }

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/Projection.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/Projection.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal;
+
+import android.support.annotation.NonNull;
+
+
+/**
+ * A column projection for content provider queries.
+ *
+ * @param <T>
+ *         The contract of the view this projection belongs to.
+ *
+ * @author Marten Gajda
+ */
+public interface Projection<T> extends Iterable<String>
+{
+    @NonNull
+    String[] toArray();
+}

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/Projection.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/Projection.java
@@ -27,7 +27,7 @@ import android.support.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public interface Projection<T> extends Iterable<String>
+public interface Projection<T>
 {
     @NonNull
     String[] toArray();

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/Table.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/Table.java
@@ -82,11 +82,8 @@ public interface Table<T>
      *
      * @param client
      *         A {@link ContentProviderClient}.
-     * @param projection
-     *         The projection to use.
-     *
      * @return A {@link View} on this table.
      */
     @NonNull
-    View<T> view(@NonNull ContentProviderClient client, @NonNull String... projection);
+    View<T> view(@NonNull ContentProviderClient client);
 }

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/View.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/View.java
@@ -42,6 +42,8 @@ public interface View<T>
      *
      * @param uriParams
      *         Additional {@link Uri} parameters to append to the query {@link Uri}.
+     * @param projection
+     *         The projection to request from the cursor.
      * @param predicate
      *         The {@link Predicate} to use as the selection.
      * @param sorting
@@ -50,7 +52,7 @@ public interface View<T>
      * @return A {@link Cursor} as returned by the {@link ContentProvider}.
      */
     @NonNull
-    Cursor rows(@NonNull UriParams uriParams, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException;
+    Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException;
 
     /**
      * Returns a {@link Table} to write to.
@@ -59,10 +61,4 @@ public interface View<T>
      */
     @NonNull
     Table<T> table();
-
-    /**
-     * Returns a new instance for this {@link View} that uses the given projection.
-     */
-    @NonNull
-    View<T> withProjection(@NonNull String... projection);
 }

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/projection/ProjectionMatcher.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/projection/ProjectionMatcher.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.projection;
+
+import org.dmfs.android.contentpal.Projection;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class ProjectionMatcher extends TypeSafeDiagnosingMatcher<Projection<?>>
+{
+    private final Iterable<String> mExpectedColumns;
+
+
+    public static Matcher<Projection<?>> projects(Iterable<String> expectedColumns)
+    {
+        return new ProjectionMatcher(expectedColumns);
+    }
+
+
+    public ProjectionMatcher(Iterable<String> expectedColumns)
+    {
+        mExpectedColumns = expectedColumns;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Projection<?> item, Description mismatchDescription)
+    {
+        Set<String> columns = new HashSet<>(Arrays.asList(item.toArray()));
+        Set<String> expectedCols = new HashSet<>(columns.size());
+        for (String col : mExpectedColumns)
+        {
+            if (!columns.contains(col))
+            {
+                mismatchDescription.appendText("Array didn't contain column '").appendText(col).appendText("'");
+                return false;
+            }
+            expectedCols.add(col);
+        }
+        if (expectedCols.size() != item.toArray().length)
+        {
+            mismatchDescription.appendText(String.format(Locale.ENGLISH, "Column count didn't equal %d", expectedCols.size()));
+            return false;
+        }
+        int count = 0;
+        for (String col : item)
+        {
+            if (!expectedCols.contains(col))
+            {
+                mismatchDescription.appendText("Iteration didn't contain column '").appendText(col).appendText("'");
+                return false;
+            }
+            count += 1;
+        }
+        if (expectedCols.size() != count)
+        {
+            mismatchDescription.appendText(String.format(Locale.ENGLISH, "Iterated column count didn't equal %d", expectedCols.size()));
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("A projection of the columns [");
+        boolean first = true;
+        for (String s : mExpectedColumns)
+        {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                description.appendText(", ");
+            }
+            description.appendText("\"");
+            description.appendText(s);
+            description.appendText("\"");
+        }
+        description.appendText("]");
+    }
+}

--- a/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/projection/ProjectionMatcherTest.java
+++ b/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/projection/ProjectionMatcherTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.projection;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.iterators.EmptyIterator;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Iterator;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class ProjectionMatcherTest
+{
+    @Test
+    public void testMatchesSafelyEmpty() throws Exception
+    {
+        Projection emptyMockProjection = failingMock(Projection.class);
+        doReturn(new String[0]).when(emptyMockProjection).toArray();
+        doReturn(new EmptyIterator<>()).when(emptyMockProjection).iterator();
+
+        assertThat(projects(EmptyIterable.<String>instance()).matches(emptyMockProjection), is(true));
+        assertThat(projects(new Seq<>("123")).matches(emptyMockProjection), is(false));
+    }
+
+
+    @Test
+    public void testMatchesSafelyNonEmpty() throws Exception
+    {
+        Projection mockProjection = failingMock(Projection.class);
+        doReturn(new String[] { "1", "2", "3" }).when(mockProjection).toArray();
+        doAnswer(new Answer<Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> answer(InvocationOnMock invocation) throws Throwable
+            {
+                return new org.dmfs.iterators.elementary.Seq<>("1", "2", "3");
+            }
+        }).when(mockProjection).iterator();
+
+        assertThat(projects(new Seq<>("1", "2", "3")).matches(mockProjection), is(true));
+        assertThat(projects(new Seq<>("3", "2", "1")).matches(mockProjection), is(true));
+    }
+
+
+    @Test
+    public void testMismatchesSafely1() throws Exception
+    {
+        Projection mockProjection = failingMock(Projection.class);
+        doReturn(new String[] { "1", "2", "3" }).when(mockProjection).toArray();
+        doAnswer(new Answer<Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> answer(InvocationOnMock invocation) throws Throwable
+            {
+                return new org.dmfs.iterators.elementary.Seq<>("1", "2", "3", "4");
+            }
+        }).when(mockProjection).iterator();
+
+        assertThat(projects(new Seq<>("1", "2", "3")).matches(mockProjection), is(false));
+        assertThat(projects(new Seq<>("3", "2", "1")).matches(mockProjection), is(false));
+    }
+
+
+    @Test
+    public void testMismatchesSafely2() throws Exception
+    {
+        Projection mockProjection = failingMock(Projection.class);
+        doReturn(new String[] { "1", "2", "3", "4" }).when(mockProjection).toArray();
+        doAnswer(new Answer<Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> answer(InvocationOnMock invocation) throws Throwable
+            {
+                return new org.dmfs.iterators.elementary.Seq<>("1", "2", "3");
+            }
+        }).when(mockProjection).iterator();
+
+        assertThat(projects(new Seq<>("1", "2", "3")).matches(mockProjection), is(false));
+        assertThat(projects(new Seq<>("3", "2", "1")).matches(mockProjection), is(false));
+    }
+
+
+    @Test
+    public void testMismatchesSafely3() throws Exception
+    {
+        Projection mockProjection = failingMock(Projection.class);
+        doReturn(new String[] { "1", "2" }).when(mockProjection).toArray();
+        doAnswer(new Answer<Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> answer(InvocationOnMock invocation) throws Throwable
+            {
+                return new org.dmfs.iterators.elementary.Seq<>("1", "2", "3");
+            }
+        }).when(mockProjection).iterator();
+
+        assertThat(projects(new Seq<>("1", "2", "3")).matches(mockProjection), is(false));
+        assertThat(projects(new Seq<>("3", "2", "1")).matches(mockProjection), is(false));
+    }
+
+
+    @Test
+    public void testMismatchesSafely4() throws Exception
+    {
+        Projection mockProjection = failingMock(Projection.class);
+        doReturn(new String[] { "1", "2", "3" }).when(mockProjection).toArray();
+        doAnswer(new Answer<Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> answer(InvocationOnMock invocation) throws Throwable
+            {
+                return new org.dmfs.iterators.elementary.Seq<>("1", "2");
+            }
+        }).when(mockProjection).iterator();
+
+        assertThat(projects(new Seq<>("1", "2", "3")).matches(mockProjection), is(false));
+        assertThat(projects(new Seq<>("3", "2", "1")).matches(mockProjection), is(false));
+    }
+
+
+    @Test
+    public void testMismatchesSafely5() throws Exception
+    {
+        Projection mockProjection = failingMock(Projection.class);
+        doReturn(new String[] { "1", "2", "4" }).when(mockProjection).toArray();
+        doAnswer(new Answer<Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> answer(InvocationOnMock invocation) throws Throwable
+            {
+                return new org.dmfs.iterators.elementary.Seq<>("1", "2", "3");
+            }
+        }).when(mockProjection).iterator();
+
+        assertThat(projects(new Seq<>("1", "2", "3")).matches(mockProjection), is(false));
+        assertThat(projects(new Seq<>("3", "2", "1")).matches(mockProjection), is(false));
+    }
+
+
+    @Test
+    public void testMismatchesSafely6() throws Exception
+    {
+        Projection mockProjection = failingMock(Projection.class);
+        doReturn(new String[] { "1", "2", "3" }).when(mockProjection).toArray();
+        doAnswer(new Answer<Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> answer(InvocationOnMock invocation) throws Throwable
+            {
+                return new org.dmfs.iterators.elementary.Seq<>("1", "2", "4");
+            }
+        }).when(mockProjection).iterator();
+
+        assertThat(projects(new Seq<>("1", "2", "3")).matches(mockProjection), is(false));
+        assertThat(projects(new Seq<>("3", "2", "1")).matches(mockProjection), is(false));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description description = new StringDescription();
+        projects(new Seq<>("123", "456")).describeTo(description);
+        assertThat(description.toString(), is("A projection of the columns [\"123\", \"456\"]"));
+    }
+
+
+    @Test
+    public void testDescribeToEmpty() throws Exception
+    {
+        Description description = new StringDescription();
+        projects(new EmptyIterable<String>()).describeTo(description);
+        assertThat(description.toString(), is("A projection of the columns []"));
+    }
+
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Composite.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Composite.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.iterables.decorators.Mapped;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.iterators.Function;
+import org.dmfs.iterators.decorators.Filtered;
+import org.dmfs.iterators.decorators.Serialized;
+import org.dmfs.iterators.filters.Distinct;
+
+import java.util.Iterator;
+import java.util.TreeSet;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class Composite<T> implements Projection<T>
+{
+    private final Iterable<Projection<T>> mDelegates;
+
+
+    public Composite(Projection<T>... delegates)
+    {
+        this(new Seq<>(delegates));
+    }
+
+
+    public Composite(Iterable<Projection<T>> delegates)
+    {
+        mDelegates = delegates;
+    }
+
+
+    @NonNull
+    @Override
+    public String[] toArray()
+    {
+        TreeSet<String> set = new TreeSet<>();
+        for (String s : this)
+        {
+            set.add(s);
+        }
+        return set.toArray(new String[set.size()]);
+    }
+
+
+    @NonNull
+    @Override
+    public Iterator<String> iterator()
+    {
+        return new Filtered<>(new Serialized<>(new Mapped<>(mDelegates, new Function<Projection<T>, Iterator<String>>()
+        {
+            @Override
+            public Iterator<String> apply(Projection<T> argument)
+            {
+                return argument.iterator();
+            }
+        }).iterator()), new Distinct<String>());
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Composite.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Composite.java
@@ -19,15 +19,13 @@ package org.dmfs.android.contentpal.projections;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Projection;
-import org.dmfs.iterables.decorators.Mapped;
 import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.iterators.Function;
-import org.dmfs.iterators.decorators.Filtered;
-import org.dmfs.iterators.decorators.Serialized;
-import org.dmfs.iterators.filters.Distinct;
+import org.dmfs.jems.function.BiFunction;
+import org.dmfs.jems.single.elementary.Reduced;
 
-import java.util.Iterator;
-import java.util.TreeSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 
 /**
@@ -54,26 +52,19 @@ public final class Composite<T> implements Projection<T>
     @Override
     public String[] toArray()
     {
-        TreeSet<String> set = new TreeSet<>();
-        for (String s : this)
-        {
-            set.add(s);
-        }
-        return set.toArray(new String[set.size()]);
-    }
-
-
-    @NonNull
-    @Override
-    public Iterator<String> iterator()
-    {
-        return new Filtered<>(new Serialized<>(new Mapped<>(mDelegates, new Function<Projection<T>, Iterator<String>>()
-        {
-            @Override
-            public Iterator<String> apply(Projection<T> argument)
-            {
-                return argument.iterator();
-            }
-        }).iterator()), new Distinct<String>());
+        List<String> projection = new Reduced<>(
+                new ArrayList<String>(32),
+                new BiFunction<ArrayList<String>, Projection<T>, ArrayList<String>>()
+                {
+                    @Override
+                    public ArrayList<String> value(ArrayList<String> strings, Projection<T> projection)
+                    {
+                        // add the strings of all projections
+                        strings.addAll(Arrays.asList(projection.toArray()));
+                        return strings;
+                    }
+                },
+                mDelegates).value();
+        return projection.toArray(new String[projection.size()]);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Composite.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Composite.java
@@ -29,6 +29,8 @@ import java.util.List;
 
 
 /**
+ * A {@link Projection} which combines other Projections by concatenating the column names into a single array.
+ *
  * @author Marten Gajda
  */
 public final class Composite<T> implements Projection<T>
@@ -36,6 +38,7 @@ public final class Composite<T> implements Projection<T>
     private final Iterable<Projection<T>> mDelegates;
 
 
+    @SafeVarargs
     public Composite(Projection<T>... delegates)
     {
         this(new Seq<>(delegates));

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/DelegatingProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/DelegatingProjection.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Projection;
+
+import java.util.Iterator;
+
+
+/**
+ * A {@link Projection} which delegates all method calls to another {@link Projection}.
+ *
+ * @author Marten Gajda
+ */
+public abstract class DelegatingProjection<T> implements Projection<T>
+{
+    private final Projection<T> mDelegate;
+
+
+    public DelegatingProjection(Projection<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @NonNull
+    @Override
+    public final String[] toArray()
+    {
+        return mDelegate.toArray();
+    }
+
+
+    @NonNull
+    @Override
+    public final Iterator<String> iterator()
+    {
+        return mDelegate.iterator();
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/DelegatingProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/DelegatingProjection.java
@@ -20,8 +20,6 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Projection;
 
-import java.util.Iterator;
-
 
 /**
  * A {@link Projection} which delegates all method calls to another {@link Projection}.
@@ -44,13 +42,5 @@ public abstract class DelegatingProjection<T> implements Projection<T>
     public final String[] toArray()
     {
         return mDelegate.toArray();
-    }
-
-
-    @NonNull
-    @Override
-    public final Iterator<String> iterator()
-    {
-        return mDelegate.iterator();
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/EmptyProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/EmptyProjection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.iterators.EmptyIterator;
+
+import java.util.Iterator;
+
+
+/**
+ * A {@link Projection} which doesn't specify any specific columns.
+ *
+ * @author Marten Gajda
+ */
+public final class EmptyProjection<T> implements Projection<T>
+{
+    @NonNull
+    @Override
+    public String[] toArray()
+    {
+        return new String[0];
+    }
+
+
+    @NonNull
+    @Override
+    public Iterator<String> iterator()
+    {
+        return EmptyIterator.instance();
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/EmptyProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/EmptyProjection.java
@@ -19,9 +19,6 @@ package org.dmfs.android.contentpal.projections;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Projection;
-import org.dmfs.iterators.EmptyIterator;
-
-import java.util.Iterator;
 
 
 /**
@@ -36,13 +33,5 @@ public final class EmptyProjection<T> implements Projection<T>
     public String[] toArray()
     {
         return new String[0];
-    }
-
-
-    @NonNull
-    @Override
-    public Iterator<String> iterator()
-    {
-        return EmptyIterator.instance();
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Joined.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/Joined.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import android.provider.ContactsContract;
+
+import org.dmfs.android.contentpal.Projection;
+
+
+/**
+ * A {@link Projection} of columns joined from another table.
+ * <p>
+ * This can be used to create composite projections for views which join two or more tables. Instead of creating a new projection for the columns of the
+ * original table in the view, this class allows it to use the original projection for the joined view.
+ * <p>
+ * A common example is the contact provider {@link ContactsContract.Data} table which also contains all columns of the {@link ContactsContract.RawContacts}
+ * table.
+ * <p>
+ * Using {@link Joined}, it's possible to add all the {@link ContactsContract.RawContacts} columns to a projection on the {@link ContactsContract.Data} table.
+ * <pre><code>
+ * Projection&lt;Data&gt; projection =
+ *     new Composite&lt;Data&gt;(
+ *         new DataProjection(),
+ *         new Joined&lt;RawContacts, Data&gt;(new RawContactsProjection()));
+ * </code></pre>
+ *
+ * @param <Original>
+ *         The table which the {@link Projection} originally belongs to
+ * @param <JoinedView>
+ *         The view which joins the original table and contains all its columns.
+ *
+ * @author Marten Gajda
+ */
+public final class Joined<Original, JoinedView> extends DelegatingProjection<JoinedView>
+{
+
+    @SuppressWarnings("unchecked")
+    public Joined(Projection<Original> delegate)
+    {
+        super((Projection<JoinedView>) delegate);
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/MultiProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/MultiProjection.java
@@ -19,10 +19,8 @@ package org.dmfs.android.contentpal.projections;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Projection;
-import org.dmfs.iterators.elementary.Seq;
 
 import java.util.Arrays;
-import java.util.Iterator;
 
 
 /**
@@ -46,13 +44,5 @@ public final class MultiProjection<T> implements Projection<T>
     public String[] toArray()
     {
         return Arrays.copyOf(mColumnNames, mColumnNames.length);
-    }
-
-
-    @NonNull
-    @Override
-    public Iterator<String> iterator()
-    {
-        return new Seq<>(mColumnNames);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/MultiProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/MultiProjection.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.iterators.elementary.Seq;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+
+/**
+ * A {@link Projection} of multiple columns.
+ *
+ * @author Marten Gajda
+ */
+public final class MultiProjection<T> implements Projection<T>
+{
+    private final String[] mColumnNames;
+
+
+    public MultiProjection(String... columnNames)
+    {
+        mColumnNames = columnNames;
+    }
+
+
+    @NonNull
+    @Override
+    public String[] toArray()
+    {
+        return Arrays.copyOf(mColumnNames, mColumnNames.length);
+    }
+
+
+    @NonNull
+    @Override
+    public Iterator<String> iterator()
+    {
+        return new Seq<>(mColumnNames);
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/SingleColProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/SingleColProjection.java
@@ -19,9 +19,6 @@ package org.dmfs.android.contentpal.projections;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Projection;
-import org.dmfs.iterators.SingletonIterator;
-
-import java.util.Iterator;
 
 
 /**
@@ -45,13 +42,5 @@ public final class SingleColProjection<T> implements Projection<T>
     public String[] toArray()
     {
         return new String[] { mColumnName };
-    }
-
-
-    @NonNull
-    @Override
-    public Iterator<String> iterator()
-    {
-        return new SingletonIterator<>(mColumnName);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/projections/SingleColProjection.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/projections/SingleColProjection.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.iterators.SingletonIterator;
+
+import java.util.Iterator;
+
+
+/**
+ * A {@link Projection} of a single column.
+ *
+ * @author Marten Gajda
+ */
+public final class SingleColProjection<T> implements Projection<T>
+{
+    private final String mColumnName;
+
+
+    public SingleColProjection(String columnName)
+    {
+        mColumnName = columnName;
+    }
+
+
+    @NonNull
+    @Override
+    public String[] toArray()
+    {
+        return new String[] { mColumnName };
+    }
+
+
+    @NonNull
+    @Override
+    public Iterator<String> iterator()
+    {
+        return new SingletonIterator<>(mColumnName);
+    }
+}

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/AllRows.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/AllRows.java
@@ -18,6 +18,7 @@ package org.dmfs.android.contentpal.rowsets;
 
 import android.support.annotation.NonNull;
 
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.predicates.AnyOf;
@@ -30,9 +31,9 @@ import org.dmfs.android.contentpal.predicates.AnyOf;
  */
 public final class AllRows<T> extends DelegatingRowSet<T>
 {
-    public AllRows(@NonNull View<T> view)
+    public AllRows(@NonNull View<T> view, @NonNull Projection projection)
     {
-        super(new QueryRowSet<>(view, new AnyOf()));
+        super(new QueryRowSet<>(view, projection, new AnyOf()));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.ClosableIterator;
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.Table;
@@ -48,12 +49,14 @@ import java.util.NoSuchElementException;
 public final class QueryRowSet<T> implements RowSet<T>
 {
     private final View<T> mView;
+    private final Projection mProjection;
     private final Predicate mPredicate;
 
 
-    public QueryRowSet(@NonNull View<T> view, @NonNull Predicate predicate)
+    public QueryRowSet(@NonNull View<T> view, @NonNull Projection projection, @NonNull Predicate predicate)
     {
         mView = view;
+        mProjection = projection;
         mPredicate = predicate;
     }
 
@@ -64,7 +67,7 @@ public final class QueryRowSet<T> implements RowSet<T>
     {
         try
         {
-            Cursor cursor = mView.rows(EmptyUriParams.INSTANCE, mPredicate, Absent.<String>absent() /* no specific sorting */);
+            Cursor cursor = mView.rows(EmptyUriParams.INSTANCE, mProjection, mPredicate,  /* no specific sorting */Absent.<String>absent());
             if (!cursor.moveToFirst())
             {
                 cursor.close();

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
@@ -86,9 +86,9 @@ public final class AccountScoped<T> implements Table<T>
 
     @NonNull
     @Override
-    public View<T> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public View<T> view(@NonNull ContentProviderClient client)
     {
-        return new org.dmfs.android.contentpal.views.AccountScoped<>(mAccount, mDelegate.view(client, projection));
+        return new org.dmfs.android.contentpal.views.AccountScoped<>(mAccount, mDelegate.view(client));
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
@@ -93,9 +93,9 @@ public final class BaseTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public View<T> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public View<T> view(@NonNull ContentProviderClient client)
     {
-        return new BaseView<T>(client, mTableUri, projection);
+        return new BaseView<T>(client, mTableUri);
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/DelegatingTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/DelegatingTable.java
@@ -80,8 +80,8 @@ public abstract class DelegatingTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public final View<T> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public final View<T> view(@NonNull ContentProviderClient client)
     {
-        return mDelegate.view(client, projection);
+        return mDelegate.view(client);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
@@ -82,9 +82,9 @@ public final class Synced<T> implements Table<T>
 
     @NonNull
     @Override
-    public View<T> view(@NonNull ContentProviderClient client, @NonNull String... projection)
+    public View<T> view(@NonNull ContentProviderClient client)
     {
-        return new org.dmfs.android.contentpal.views.Synced<>(mDelegate.view(client, projection));
+        return new org.dmfs.android.contentpal.views.Synced<>(mDelegate.view(client));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tools/RowCount.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tools/RowCount.java
@@ -23,6 +23,7 @@ import android.provider.BaseColumns;
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.predicates.AnyOf;
+import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
 import org.dmfs.jems.single.Single;
 import org.dmfs.optional.Absent;
@@ -58,7 +59,7 @@ public final class RowCount<T> implements Single<Integer>
         Cursor cursor = null;
         try
         {
-            cursor = mView.withProjection(BaseColumns._ID).rows(EmptyUriParams.INSTANCE, mPredicate, Absent.<String>absent());
+            cursor = mView.rows(EmptyUriParams.INSTANCE, new SingleColProjection(BaseColumns._ID), mPredicate, Absent.<String>absent());
             return cursor.getCount();
         }
         catch (RemoteException e)

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
@@ -22,6 +22,7 @@ import android.os.RemoteException;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
@@ -54,9 +55,9 @@ public final class AccountScoped<T> implements View<T>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(new AccountScopedParams(mAccount, uriParams), new AllOf(predicate, new AccountEq(mAccount)), sorting);
+        return mDelegate.rows(new AccountScopedParams(mAccount, uriParams), projection, new AllOf(predicate, new AccountEq(mAccount)), sorting);
     }
 
 
@@ -67,11 +68,4 @@ public final class AccountScoped<T> implements View<T>
         return new org.dmfs.android.contentpal.tables.AccountScoped<>(mAccount, mDelegate.table());
     }
 
-
-    @NonNull
-    @Override
-    public View<T> withProjection(@NonNull String... projection)
-    {
-        return new AccountScoped<>(mAccount, mDelegate.withProjection(projection));
-    }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/DelegatingView.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/DelegatingView.java
@@ -21,6 +21,7 @@ import android.os.RemoteException;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
@@ -48,9 +49,9 @@ public abstract class DelegatingView<T> implements View<T>
 
     @NonNull
     @Override
-    public final Cursor rows(@NonNull UriParams uriParams, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public final Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(uriParams, predicate, sorting);
+        return mDelegate.rows(uriParams, projection, predicate, sorting);
     }
 
 
@@ -59,13 +60,5 @@ public abstract class DelegatingView<T> implements View<T>
     public final Table<T> table()
     {
         return mDelegate.table();
-    }
-
-
-    @NonNull
-    @Override
-    public View<T> withProjection(@NonNull String... projection)
-    {
-        return mDelegate.withProjection(projection);
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/Sorted.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/Sorted.java
@@ -21,6 +21,7 @@ import android.os.RemoteException;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
@@ -52,9 +53,9 @@ public final class Sorted<T> implements View<T>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(uriParams, predicate, new Present<>(sorting.value(mSorting)));
+        return mDelegate.rows(uriParams, projection, predicate, new Present<>(sorting.value(mSorting)));
     }
 
 
@@ -63,13 +64,5 @@ public final class Sorted<T> implements View<T>
     public Table<T> table()
     {
         return mDelegate.table();
-    }
-
-
-    @NonNull
-    @Override
-    public View<T> withProjection(@NonNull String... projection)
-    {
-        return new Sorted<>(mSorting, mDelegate.withProjection(projection));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
@@ -21,6 +21,7 @@ import android.os.RemoteException;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
@@ -50,9 +51,9 @@ public final class Synced<T> implements View<T>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(new SyncParams(uriParams), predicate, sorting);
+        return mDelegate.rows(new SyncParams(uriParams), projection, predicate, sorting);
     }
 
 
@@ -61,13 +62,5 @@ public final class Synced<T> implements View<T>
     public Table<T> table()
     {
         return new org.dmfs.android.contentpal.tables.Synced<>(mDelegate.table());
-    }
-
-
-    @NonNull
-    @Override
-    public View<T> withProjection(@NonNull String... projection)
-    {
-        return new Synced<>(mDelegate.withProjection(projection));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/CompositeTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/CompositeTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class CompositeTest
+{
+    @Test
+    public void testEmpty() throws Exception
+    {
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>())), projects(EmptyIterable.<String>instance()));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>(), new EmptyProjection())),
+                projects(EmptyIterable.<String>instance()));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>(), new EmptyProjection(), new EmptyProjection())),
+                projects(EmptyIterable.<String>instance()));
+    }
+
+
+    @Test
+    public void testNonEmpty() throws Exception
+    {
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc"))), projects(new Seq<>("abc")));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"))),
+                projects(new Seq<>("abc", "xyz", "qrs")));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc"), new MultiProjection<Contract>("xyz"))),
+                projects(new Seq<>("abc", "xyz")));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"))),
+                projects(new Seq<>("abc", "xyz", "qrs")));
+        assertThat(new Composite<>(
+                        new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"), new MultiProjection<Contract>("123", "456", "789"))),
+                projects(new Seq<>("abc", "xyz", "qrs", "123", "456", "789")));
+    }
+
+
+    @Test
+    public void testDuplicateColumns() throws Exception
+    {
+        assertThat(new Composite<>(
+                        new Seq<Projection<Contract>>(
+                                new MultiProjection<Contract>("abc", "xyz", "qrs", "123", "456", "789"),
+                                new MultiProjection<Contract>("123", "456", "789", "abc", "xyz", "qrs"))),
+                projects(new Seq<>("abc", "xyz", "qrs", "123", "456", "789")));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/CompositeTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/CompositeTest.java
@@ -18,11 +18,11 @@ package org.dmfs.android.contentpal.projections;
 
 import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.testing.table.Contract;
-import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projectsEmpty;
 import static org.junit.Assert.assertThat;
 
 
@@ -34,27 +34,24 @@ public class CompositeTest
     @Test
     public void testEmpty() throws Exception
     {
-        assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>())), projects(EmptyIterable.<String>instance()));
-        assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>(), new EmptyProjection())),
-                projects(EmptyIterable.<String>instance()));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>())), projectsEmpty());
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>(), new EmptyProjection())), projectsEmpty());
         assertThat(new Composite<>(new Seq<Projection<Contract>>(new EmptyProjection<Contract>(), new EmptyProjection(), new EmptyProjection())),
-                projects(EmptyIterable.<String>instance()));
+                projectsEmpty());
     }
 
 
     @Test
     public void testNonEmpty() throws Exception
     {
-        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc"))), projects(new Seq<>("abc")));
-        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"))),
-                projects(new Seq<>("abc", "xyz", "qrs")));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc"))), projects("abc"));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"))), projects("abc", "xyz", "qrs"));
         assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc"), new MultiProjection<Contract>("xyz"))),
-                projects(new Seq<>("abc", "xyz")));
-        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"))),
-                projects(new Seq<>("abc", "xyz", "qrs")));
+                projects("abc", "xyz"));
+        assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"))), projects("abc", "xyz", "qrs"));
         assertThat(new Composite<>(
                         new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"), new MultiProjection<Contract>("123", "456", "789"))),
-                projects(new Seq<>("abc", "xyz", "qrs", "123", "456", "789")));
+                projects("abc", "xyz", "qrs", "123", "456", "789"));
     }
 
 
@@ -64,8 +61,8 @@ public class CompositeTest
         assertThat(new Composite<>(
                         new Seq<Projection<Contract>>(
                                 new MultiProjection<Contract>("abc", "xyz", "qrs", "123", "456", "789"),
-                                new MultiProjection<Contract>("123", "456", "789", "abc", "xyz", "qrs"))),
-                projects(new Seq<>("abc", "xyz", "qrs", "123", "456", "789")));
+                                new MultiProjection<Contract>("abc", "xyz", "qrs", "123", "456", "789"))),
+                projects("abc", "xyz", "qrs", "123", "456", "789", "abc", "xyz", "qrs", "123", "456", "789"));
     }
 
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/DelegatingProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/DelegatingProjectionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class DelegatingProjectionTest
+{
+
+    @Test
+    public void test()
+    {
+        String[] dummyArray = new String[0];
+        Iterator<String> dummyIterator = failingMock(Iterator.class);
+        Projection<Contract> mockProjection = failingMock(Projection.class);
+        doReturn(dummyArray).when(mockProjection).toArray();
+        doReturn(dummyIterator).when(mockProjection).iterator();
+
+        assertThat(new TestProjection<Contract>(mockProjection).iterator(), sameInstance(dummyIterator));
+        assertThat(new TestProjection<Contract>(mockProjection).toArray(), sameInstance(dummyArray));
+    }
+
+
+    private final static class TestProjection<T> extends DelegatingProjection<T>
+    {
+
+        public TestProjection(Projection<T> delegate)
+        {
+            super(delegate);
+        }
+    }
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/DelegatingProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/DelegatingProjectionTest.java
@@ -41,10 +41,8 @@ public class DelegatingProjectionTest
         Iterator<String> dummyIterator = failingMock(Iterator.class);
         Projection<Contract> mockProjection = failingMock(Projection.class);
         doReturn(dummyArray).when(mockProjection).toArray();
-        doReturn(dummyIterator).when(mockProjection).iterator();
 
-        assertThat(new TestProjection<Contract>(mockProjection).iterator(), sameInstance(dummyIterator));
-        assertThat(new TestProjection<Contract>(mockProjection).toArray(), sameInstance(dummyArray));
+        assertThat(new TestProjection<>(mockProjection).toArray(), sameInstance(dummyArray));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/EmptyProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/EmptyProjectionTest.java
@@ -17,10 +17,9 @@
 package org.dmfs.android.contentpal.projections;
 
 import org.dmfs.android.contentpal.testing.table.Contract;
-import org.dmfs.iterables.EmptyIterable;
 import org.junit.Test;
 
-import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projectsEmpty;
 import static org.junit.Assert.assertThat;
 
 
@@ -32,7 +31,7 @@ public class EmptyProjectionTest
     @Test
     public void test() throws Exception
     {
-        assertThat(new EmptyProjection<Contract>(), projects(EmptyIterable.<String>instance()));
+        assertThat(new EmptyProjection<Contract>(), projectsEmpty());
     }
 
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/EmptyProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/EmptyProjectionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.dmfs.iterables.EmptyIterable;
+import org.junit.Test;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class EmptyProjectionTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new EmptyProjection<Contract>(), projects(EmptyIterable.<String>instance()));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/JoinedProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/JoinedProjectionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class JoinedProjectionTest
+{
+
+    @Test
+    public void test()
+    {
+        String[] dummyArray = new String[0];
+        Iterator<String> dummyIterator = failingMock(Iterator.class);
+        Projection<Contract> mockProjection = failingMock(Projection.class);
+        doReturn(dummyArray).when(mockProjection).toArray();
+        doReturn(dummyIterator).when(mockProjection).iterator();
+
+        assertThat(new Joined<Contract, Object>(mockProjection).iterator(), sameInstance(dummyIterator));
+        assertThat(new Joined<Contract, Object>(mockProjection).toArray(), sameInstance(dummyArray));
+    }
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/JoinedProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/JoinedProjectionTest.java
@@ -41,9 +41,7 @@ public class JoinedProjectionTest
         Iterator<String> dummyIterator = failingMock(Iterator.class);
         Projection<Contract> mockProjection = failingMock(Projection.class);
         doReturn(dummyArray).when(mockProjection).toArray();
-        doReturn(dummyIterator).when(mockProjection).iterator();
 
-        assertThat(new Joined<Contract, Object>(mockProjection).iterator(), sameInstance(dummyIterator));
-        assertThat(new Joined<Contract, Object>(mockProjection).toArray(), sameInstance(dummyArray));
+        assertThat(new Joined<>(mockProjection).toArray(), sameInstance(dummyArray));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/MultiProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/MultiProjectionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class MultiProjectionTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new MultiProjection<Contract>(), projects(EmptyIterable.<String>instance()));
+        assertThat(new MultiProjection<Contract>("abc"), projects(new Seq<>("abc")));
+        assertThat(new MultiProjection<Contract>("abc", "xyz"), projects(new Seq<>("abc", "xyz")));
+        assertThat(new MultiProjection<Contract>("abc", "xyz", "qrs"), projects(new Seq<>("abc", "xyz", "qrs")));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/MultiProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/MultiProjectionTest.java
@@ -17,11 +17,10 @@
 package org.dmfs.android.contentpal.projections;
 
 import org.dmfs.android.contentpal.testing.table.Contract;
-import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projectsEmpty;
 import static org.junit.Assert.assertThat;
 
 
@@ -33,10 +32,10 @@ public class MultiProjectionTest
     @Test
     public void test() throws Exception
     {
-        assertThat(new MultiProjection<Contract>(), projects(EmptyIterable.<String>instance()));
-        assertThat(new MultiProjection<Contract>("abc"), projects(new Seq<>("abc")));
-        assertThat(new MultiProjection<Contract>("abc", "xyz"), projects(new Seq<>("abc", "xyz")));
-        assertThat(new MultiProjection<Contract>("abc", "xyz", "qrs"), projects(new Seq<>("abc", "xyz", "qrs")));
+        assertThat(new MultiProjection<Contract>(), projectsEmpty());
+        assertThat(new MultiProjection<Contract>("abc"), projects("abc"));
+        assertThat(new MultiProjection<Contract>("abc", "xyz"), projects("abc", "xyz"));
+        assertThat(new MultiProjection<Contract>("abc", "xyz", "qrs"), projects("abc", "xyz", "qrs"));
     }
 
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/SingleColProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/SingleColProjectionTest.java
@@ -17,7 +17,6 @@
 package org.dmfs.android.contentpal.projections;
 
 import org.dmfs.android.contentpal.testing.table.Contract;
-import org.dmfs.iterables.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
@@ -32,6 +31,6 @@ public class SingleColProjectionTest
     @Test
     public void test() throws Exception
     {
-        assertThat(new SingleColProjection<Contract>("abc"), projects(new Seq<>("abc")));
+        assertThat(new SingleColProjection<Contract>("abc"), projects("abc"));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/SingleColProjectionTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/SingleColProjectionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.projections;
+
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class SingleColProjectionTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new SingleColProjection<Contract>("abc"), projects(new Seq<>("abc")));
+    }
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/rowdata/CharSequenceRowDataTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/rowdata/CharSequenceRowDataTest.java
@@ -22,8 +22,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
-import static org.dmfs.android.contentpal.testing.contentvalues.NullValue.withNullValue;
 import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.contentvalues.NullValue.withNullValue;
 import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
 import static org.junit.Assert.assertThat;
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/tools/RowCountTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/tools/RowCountTest.java
@@ -20,9 +20,9 @@ import android.annotation.TargetApi;
 import android.database.Cursor;
 import android.os.Build;
 import android.os.RemoteException;
-import android.provider.BaseColumns;
 
 import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
 import org.dmfs.jems.mockito.answers.FailAnswer;
@@ -35,6 +35,7 @@ import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -55,12 +56,10 @@ public final class RowCountTest
     public void test_thatCursorGetCountIsReturned() throws Exception
     {
         View<Object> mockView = failingMock(View.class);
-        View<Object> mockViewProj = failingMock(View.class);
         Predicate dummyPredicate = dummy(Predicate.class);
         Cursor mockCursor = failingMock(Cursor.class);
 
-        doReturn(mockViewProj).when(mockView).withProjection(BaseColumns._ID);
-        doReturn(mockCursor).when(mockViewProj).rows(EmptyUriParams.INSTANCE, dummyPredicate, Absent.<String>absent());
+        doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(Absent.<String>absent()));
         doReturn(4).when(mockCursor).getCount();
         doNothing().when(mockCursor).close();
 
@@ -73,11 +72,10 @@ public final class RowCountTest
     public void test_ctorWithoutPredicate_predicateHasSelection1() throws Exception
     {
         View<Object> mockView = failingMock(View.class);
-        View<Object> mockViewProj = failingMock(View.class);
         Cursor mockCursor = failingMock(Cursor.class);
 
-        doReturn(mockViewProj).when(mockView).withProjection(BaseColumns._ID);
-        doReturn(mockCursor).when(mockViewProj).rows(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"), same(Absent.<String>absent()));
+        doReturn(mockCursor).when(mockView)
+                .rows(same(EmptyUriParams.INSTANCE), any(Projection.class), predicateWithSelection("1"), same(Absent.<String>absent()));
         doReturn(5).when(mockCursor).getCount();
         doNothing().when(mockCursor).close();
 
@@ -91,11 +89,10 @@ public final class RowCountTest
     public void test_whenRowsThrows_ExceptionIsThrown() throws Exception
     {
         View<Object> mockView = failingMock(View.class);
-        View<Object> mockViewProj = failingMock(View.class);
         Predicate dummyPredicate = dummy(Predicate.class);
 
-        doReturn(mockViewProj).when(mockView).withProjection(BaseColumns._ID);
-        doThrow(new RemoteException("msg")).when(mockViewProj).rows(EmptyUriParams.INSTANCE, dummyPredicate, Absent.<String>absent());
+        doThrow(new RemoteException("msg")).when(mockView)
+                .rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(Absent.<String>absent()));
 
         new RowCount<>(mockView, dummyPredicate).value();
     }
@@ -105,12 +102,10 @@ public final class RowCountTest
     public void test_whenCursorGetCountThrows_CursorIsClosed() throws Exception
     {
         View<Object> mockView = mock(View.class, new FailAnswer());
-        View<Object> mockViewProj = mock(View.class, new FailAnswer());
         Predicate dummyPredicate = mock(Predicate.class, new FailAnswer());
         Cursor mockCursor = mock(Cursor.class, new FailAnswer());
 
-        doReturn(mockViewProj).when(mockView).withProjection(BaseColumns._ID);
-        doReturn(mockCursor).when(mockViewProj).rows(EmptyUriParams.INSTANCE, dummyPredicate, Absent.<String>absent());
+        doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(Absent.<String>absent()));
         doThrow(new RuntimeException("msg")).when(mockCursor).getCount();
         doNothing().when(mockCursor).close();
 


### PR DESCRIPTION
This commit adds a dedicated `Projection` type which replaces plain String arrays. This type allows to declare projections for views in a convenient manner.

This also changes the projection from being a `View` property to being a `RowSet` property which is passed to the `View` when it's actually queried. This way a single `View` per table is sufficient.