### PR TITLE
Move the group:artifact:version dependency declarations to a single g…

### DIFF
--- a/.idea/dictionaries/dictionary.xml
+++ b/.idea/dictionaries/dictionary.xml
@@ -1,7 +1,8 @@
 <component name="ProjectDictionaryState">
-  <dictionary name="marten">
+  <dictionary name="dictionary">
     <words>
       <w>dmfs</w>
+      <w>jems</w>
     </words>
   </dictionary>
 </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,10 +33,10 @@ android {
 dependencies {
     implementation project(':contactspal')
     implementation project(':calendarpal')
-    implementation 'com.android.support:appcompat-v7:' + SUPPORT_LIBRARY_VERSION
-    implementation 'com.android.support:design:' + SUPPORT_LIBRARY_VERSION
-    implementation 'org.dmfs:jems:' + JEMS_VERSION
-    implementation 'org.dmfs:rfc5545-datetime:' + RFC5545_DATETIME_VERSION
+    implementation deps.support_appcompat
+    implementation deps.support_design
+    implementation deps.dmfs_jems
+    implementation deps.dmfs_datetime
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation deps.junit
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ allprojects {
     }
 }
 
+apply from: "dependencies.gradle"
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/calendarpal/build.gradle
+++ b/calendarpal/build.gradle
@@ -42,14 +42,14 @@ android {
 dependencies {
     api project(':contentpal')
 
-    implementation 'com.android.support:support-annotations:' + SUPPORT_LIBRARY_VERSION
-    implementation 'org.dmfs:rfc5545-datetime:' + RFC5545_DATETIME_VERSION
-    implementation 'org.dmfs:lib-recur:0.10'
-    implementation 'org.dmfs:jems:' + JEMS_VERSION
+    implementation deps.support_annotations
+    implementation deps.dmfs_datetime
+    implementation deps.dmfs_lib_recur
+    implementation deps.dmfs_jems
 
     testImplementation project(':contentpal-testing')
-    testImplementation 'junit:junit:' + JUNIT_VERSION
-    testImplementation 'org.mockito:mockito-core:' + MOCKITO_VERSION
-    testImplementation 'org.robolectric:robolectric:' + ROBOLECTRIC_VERSION
-    testImplementation 'org.dmfs:jems-testing:' + JEMS_VERSION
+    testImplementation deps.junit
+    testImplementation deps.mockito
+    testImplementation deps.roboelectric
+    testImplementation deps.dmfs_jems_testing
 }

--- a/contactspal/build.gradle
+++ b/contactspal/build.gradle
@@ -42,11 +42,11 @@ android {
 dependencies {
     api project(':contentpal')
 
-    implementation 'com.android.support:support-annotations:' + SUPPORT_LIBRARY_VERSION
-    implementation 'org.dmfs:jems:' + JEMS_VERSION
+    implementation deps.support_annotations
+    implementation deps.dmfs_jems
 
-    testImplementation 'junit:junit:' + JUNIT_VERSION
-    testImplementation 'org.mockito:mockito-core:' + MOCKITO_VERSION
-    testImplementation 'org.robolectric:robolectric:' + ROBOLECTRIC_VERSION
     testImplementation project(':contentpal-testing')
+    testImplementation deps.junit
+    testImplementation deps.mockito
+    testImplementation deps.roboelectric
 }

--- a/contentpal-api/build.gradle
+++ b/contentpal-api/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    api 'org.dmfs:jems:' + JEMS_VERSION
+    api deps.dmfs_jems
 
-    implementation 'com.android.support:support-annotations:' + SUPPORT_LIBRARY_VERSION
+    implementation deps.support_annotations
 }

--- a/contentpal-testing/build.gradle
+++ b/contentpal-testing/build.gradle
@@ -39,9 +39,9 @@ android {
 
 dependencies {
     implementation project(':contentpal-api')
-    implementation 'org.hamcrest:hamcrest-library:' + HAMCREST_VERSION
-    implementation 'junit:junit:' + JUNIT_VERSION
-    implementation 'org.mockito:mockito-core:' + MOCKITO_VERSION
-    implementation 'org.dmfs:jems-testing:' + JEMS_VERSION
-    implementation 'com.android.support:support-annotations:' + SUPPORT_LIBRARY_VERSION
+    implementation deps.support_annotations
+    implementation deps.junit
+    implementation deps.hamcrest
+    implementation deps.mockito
+    implementation deps.dmfs_jems_testing
 }

--- a/contentpal/build.gradle
+++ b/contentpal/build.gradle
@@ -41,14 +41,14 @@ android {
 
 dependencies {
     api project(':contentpal-api')
-    api 'org.dmfs:jems:' + JEMS_VERSION
+    api deps.dmfs_jems
 
-    implementation 'com.android.support:support-annotations:' + SUPPORT_LIBRARY_VERSION
+    implementation deps.support_annotations
 
     testImplementation project(':contentpal-testing')
-    testImplementation 'junit:junit:' + JUNIT_VERSION
-    testImplementation 'org.mockito:mockito-core:' + MOCKITO_VERSION
-    testImplementation 'org.robolectric:robolectric:' + ROBOLECTRIC_VERSION
-    testImplementation 'org.dmfs:jems-testing:' + JEMS_VERSION
+    testImplementation deps.junit
+    testImplementation deps.mockito
+    testImplementation deps.roboelectric
+    testImplementation deps.dmfs_jems_testing
 
 }

--- a/contenttestpal/build.gradle
+++ b/contenttestpal/build.gradle
@@ -32,6 +32,6 @@ android {
 }
 
 dependencies {
-    implementation project(':contentpal');
-    implementation 'org.hamcrest:hamcrest-library:' + HAMCREST_VERSION
+    implementation project(':contentpal')
+    implementation deps.hamcrest
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,19 @@
+def support_lib_version = '25.3.1'
+def jems_version = '1.13'
+
+ext.deps = [
+        support_appcompat  : "com.android.support:appcompat-v7:$support_lib_version",
+        support_annotations: "com.android.support:support-annotations:$support_lib_version",
+        support_design     : "com.android.support:design:$support_lib_version",
+
+        dmfs_jems          : "org.dmfs:jems:$jems_version",
+        dmfs_jems_testing  : "org.dmfs:jems-testing:$jems_version",
+        dmfs_datetime      : 'org.dmfs:rfc5545-datetime:0.2.4',
+        dmfs_lib_recur     : 'org.dmfs:lib-recur:0.10',
+
+        junit              : 'junit:junit:4.12',
+        hamcrest           : 'org.hamcrest:hamcrest-library:1.3',
+        mockito            : 'org.mockito:mockito-core:2.10.0',
+        roboelectric       : 'org.robolectric:robolectric:3.1.4'
+]
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,12 +12,3 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-## Keep this in sync with the build tools version
-SUPPORT_LIBRARY_VERSION=25.3.1
-JEMS_VERSION=1.13
-# Test utils
-JUNIT_VERSION=4.12
-HAMCREST_VERSION=1.3
-MOCKITO_VERSION=2.10.0
-ROBOLECTRIC_VERSION=3.1.4
-RFC5545_DATETIME_VERSION=0.2.4


### PR DESCRIPTION
…radle file. #113 

---

Unfortunately code completion doesn't work. I tried it with a class with fields as well, like:
```
class Foo {
    String junit = "org.junit..."
}

ext.foo = new Foo()

// and then
dependencies
{
     implementation foo.ju    // doesn't offer it, only if the class is defined in the same file
}
```
Simply referencing a variable from another file didn't work either. Just through that `ext`.
I didn't want to spend more time with it.

Maybe later with Kotlin instead of Groovy, it will be solved. I would expect better IDE support for Kotlin.

Anyway, it's still easier to type those short names in my opinion.

The hints for higher available version are not there. Okay to create a ticket to add the plugin and possibly appending its task to the build task?