### PR TITLE
Add gradle plugin with 'dependencyUpdates' task that list the availab…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+apply plugin: 'com.github.ben-manes.versions'
 
 buildscript {
     repositories {
@@ -9,6 +10,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
         classpath 'org.jacoco:org.jacoco.core:0.7.9'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     }
 }
 


### PR DESCRIPTION
…le versions for the dependencies. #148 

---

A current output of the `updateDependencies` task:

```
> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.github.ben-manes:gradle-versions-plugin:0.17.0
 - com.dicedmelon.gradle:jacoco-android:0.1.2
 - org.dmfs:jems:1.15
 - org.dmfs:jems-testing:1.15
 - junit:junit:4.12
 - org.jacoco:org.jacoco.agent:0.7.9
 - org.jacoco:org.jacoco.ant:0.7.9
 - org.jacoco:org.jacoco.core:0.7.9
 - org.dmfs:rfc5545-datetime:0.2.4

The following dependencies have later milestone versions:
 - com.android.support:appcompat-v7 [25.3.1 -> 27.0.2]
 - com.android.support:design [25.3.1 -> 27.0.2]
 - com.android.tools.build:gradle [3.0.1 -> 3.1.0-alpha05]
 - org.hamcrest:hamcrest-library [1.3 -> 1.4-atlassian-1]
 - org.dmfs:lib-recur [0.10 -> 0.10.1]
 - org.mockito:mockito-core [2.10.0 -> 2.13.0]
 - org.robolectric:robolectric [3.1.4 -> 3.6.1]
 - com.android.support:support-annotations [25.3.1 -> 27.0.2]

Generated report file build/dependencyUpdates/report.txt

```