### PR TITLE
Move dependency lists to dependencies.gradle file. #151

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,13 +30,4 @@ android {
     }
 }
 
-dependencies {
-    implementation project(':contactspal')
-    implementation project(':calendarpal')
-    implementation deps.support_appcompat
-    implementation deps.support_design
-    implementation deps.dmfs_jems
-    implementation deps.dmfs_datetime
-
-    testImplementation deps.junit
-}
+dependencies Demo_App

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,3 @@ allprojects {
 }
 
 apply from: "dependencies.gradle"
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}

--- a/calendarpal/build.gradle
+++ b/calendarpal/build.gradle
@@ -39,17 +39,4 @@ android {
     }
 }
 
-dependencies {
-    api project(':contentpal')
-
-    implementation deps.support_annotations
-    implementation deps.dmfs_datetime
-    implementation deps.dmfs_lib_recur
-    implementation deps.dmfs_jems
-
-    testImplementation project(':contentpal-testing')
-    testImplementation deps.junit
-    testImplementation deps.mockito
-    testImplementation deps.roboelectric
-    testImplementation deps.dmfs_jems_testing
-}
+dependencies CalendarPal

--- a/contactspal/build.gradle
+++ b/contactspal/build.gradle
@@ -39,14 +39,4 @@ android {
     }
 }
 
-dependencies {
-    api project(':contentpal')
-
-    implementation deps.support_annotations
-    implementation deps.dmfs_jems
-
-    testImplementation project(':contentpal-testing')
-    testImplementation deps.junit
-    testImplementation deps.mockito
-    testImplementation deps.roboelectric
-}
+dependencies ContactsPal

--- a/contentpal-api/build.gradle
+++ b/contentpal-api/build.gradle
@@ -40,8 +40,4 @@ android {
     }
 }
 
-dependencies {
-    api deps.dmfs_jems
-
-    implementation deps.support_annotations
-}
+dependencies ContentPal_Api

--- a/contentpal-testing/build.gradle
+++ b/contentpal-testing/build.gradle
@@ -37,11 +37,4 @@ android {
     }
 }
 
-dependencies {
-    implementation project(':contentpal-api')
-    implementation deps.support_annotations
-    implementation deps.junit
-    implementation deps.hamcrest
-    implementation deps.mockito
-    implementation deps.dmfs_jems_testing
-}
+dependencies ContentPal_Testing

--- a/contentpal/build.gradle
+++ b/contentpal/build.gradle
@@ -39,16 +39,4 @@ android {
     }
 }
 
-dependencies {
-    api project(':contentpal-api')
-    api deps.dmfs_jems
-
-    implementation deps.support_annotations
-
-    testImplementation project(':contentpal-testing')
-    testImplementation deps.junit
-    testImplementation deps.mockito
-    testImplementation deps.roboelectric
-    testImplementation deps.dmfs_jems_testing
-
-}
+dependencies ContentPal

--- a/contenttestpal/build.gradle
+++ b/contenttestpal/build.gradle
@@ -31,7 +31,4 @@ android {
     }
 }
 
-dependencies {
-    implementation project(':contentpal')
-    implementation deps.hamcrest
-}
+dependencies ContentTestPal

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,15 +1,16 @@
+apply plugin: 'java'
+
 def support_lib_version = '25.3.1'
 def jems_version = '1.15'
-
-ext.deps = [
+def d = [
         support_appcompat  : "com.android.support:appcompat-v7:$support_lib_version",
         support_annotations: "com.android.support:support-annotations:$support_lib_version",
         support_design     : "com.android.support:design:$support_lib_version",
 
-        dmfs_jems          : "org.dmfs:jems:$jems_version",
-        dmfs_jems_testing  : "org.dmfs:jems-testing:$jems_version",
-        dmfs_datetime      : 'org.dmfs:rfc5545-datetime:0.2.4',
-        dmfs_lib_recur     : 'org.dmfs:lib-recur:0.10',
+        jems               : "org.dmfs:jems:$jems_version",
+        jems_testing       : "org.dmfs:jems-testing:$jems_version",
+        datetime           : 'org.dmfs:rfc5545-datetime:0.2.4',
+        librecur           : 'org.dmfs:lib-recur:0.10',
 
         junit              : 'junit:junit:4.12',
         hamcrest           : 'org.hamcrest:hamcrest-library:1.3',
@@ -17,3 +18,64 @@ ext.deps = [
         roboelectric       : 'org.robolectric:robolectric:3.1.4'
 ]
 
+ext.ContentPal_Api = {
+    api d.jems
+    implementation d.support_annotations
+}
+
+ext.ContentPal = {
+    api project(':contentpal-api')
+    api d.jems
+    implementation d.support_annotations
+    testImplementation project(':contentpal-testing')
+    testImplementation d.jems_testing
+    testImplementation d.junit
+    testImplementation d.mockito
+    testImplementation d.roboelectric
+}
+
+ext.ContactsPal = {
+    api project(':contentpal')
+    implementation d.support_annotations
+    implementation d.jems
+    testImplementation project(':contentpal-testing')
+    testImplementation d.junit
+    testImplementation d.mockito
+    testImplementation d.roboelectric
+}
+
+ext.CalendarPal = {
+    api project(':contentpal')
+    implementation d.support_annotations
+    implementation d.datetime
+    implementation d.librecur
+    implementation d.jems
+    testImplementation project(':contentpal-testing')
+    testImplementation d.jems_testing
+    testImplementation d.junit
+    testImplementation d.mockito
+    testImplementation d.roboelectric
+}
+
+ext.ContentPal_Testing = {
+    implementation project(':contentpal-api')
+    implementation d.jems_testing
+    implementation d.support_annotations
+    implementation d.junit
+    implementation d.hamcrest
+    implementation d.mockito
+}
+
+ext.ContentTestPal = {
+    implementation project(':contentpal')
+    implementation d.hamcrest
+}
+
+ext.Demo_App = {
+    implementation project(':contactspal')
+    implementation project(':calendarpal')
+    implementation d.support_appcompat
+    implementation d.support_design
+    implementation d.jems
+    implementation d.datetime
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-all.zip


### PR DESCRIPTION

Small note: Gradle complained with some error about that 'clean' task in the root build.gradle file, not sure why, but I just removed it.

Also updated gradle to 4.3 while I was troubleshooting, it is probably not needed but it doesn't hurt either.