### PR TITLE
Add unit tests and improve some existing ones. Implements #89

### DIFF
--- a/contentpal-testing/build.gradle
+++ b/contentpal-testing/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     implementation deps.hamcrest
     implementation deps.mockito
     implementation deps.dmfs_jems_testing
+    testImplementation deps.roboelectric
 }

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/TargetMatcher.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/TargetMatcher.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.contentoperationbuilder;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.dmfs.android.contentpal.testing.tools.Field;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static org.hamcrest.CoreMatchers.is;
+
+
+/**
+ * A {@link Matcher} which matches the {@link Uri} of a {@link ContentProviderOperation.Builder}.
+ *
+ * @author Marten Gajda
+ */
+public final class TargetMatcher extends TypeSafeDiagnosingMatcher<ContentProviderOperation.Builder>
+{
+    private final Matcher<Uri> mValueMatcher;
+
+
+    public static TargetMatcher targets(String uri)
+    {
+        return new TargetMatcher(is(Uri.parse(uri)));
+    }
+
+
+    public static TargetMatcher targets(Uri uri)
+    {
+        return new TargetMatcher(is(uri));
+    }
+
+
+    public static TargetMatcher targets(Matcher<Uri> uriMatcher)
+    {
+        return new TargetMatcher(uriMatcher);
+    }
+
+
+    public TargetMatcher(Matcher<Uri> valueMatchers)
+    {
+        mValueMatcher = valueMatchers;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(ContentProviderOperation.Builder builder, Description mismatchDescription)
+    {
+        Uri uri = new Field<Uri>(builder, "mUri").value();
+
+        if (!mValueMatcher.matches(uri))
+        {
+            mismatchDescription.appendText("Operation target ");
+            mValueMatcher.describeMismatch(uri, mismatchDescription);
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("Operation target ");
+        mValueMatcher.describeTo(description);
+    }
+}

--- a/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/CountMatcherTest.java
+++ b/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/CountMatcherTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.contentoperationbuilder;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withExpectedCount;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class CountMatcherTest
+{
+    @Test
+    public void testMatches() throws Exception
+    {
+        assertThat(withExpectedCount(5).matches(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(5)), is(true));
+        assertThat(withExpectedCount(5).matches(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(4)), is(false));
+        assertThat(withExpectedCount(0).matches(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(0)), is(true));
+        assertThat(withExpectedCount(5).matches(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(0)), is(false));
+
+        assertThat(withoutExpectedCount().matches(ContentProviderOperation.newUpdate(dummy(Uri.class))), is(true));
+        assertThat(withoutExpectedCount().matches(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(0)), is(false));
+        assertThat(withoutExpectedCount().matches(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(4)), is(false));
+    }
+
+
+    @Test
+    public void testMatchesSafelyMismatch() throws Exception
+    {
+        Description description = new StringDescription();
+        withExpectedCount(5).matchesSafely(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(3), description);
+        assertThat(description.toString(), is("expected 3 results"));
+    }
+
+
+    @Test
+    public void testMatchesSafelyMismatch2() throws Exception
+    {
+        Description description = new StringDescription();
+        withExpectedCount(5).matchesSafely(ContentProviderOperation.newUpdate(dummy(Uri.class)), description);
+        assertThat(description.toString(), is("expected no specific number of results"));
+    }
+
+
+    @Test
+    public void testMatchesSafelyMismatch3() throws Exception
+    {
+        Description description = new StringDescription();
+        withoutExpectedCount().matchesSafely(ContentProviderOperation.newUpdate(dummy(Uri.class)).withExpectedCount(3), description);
+        assertThat(description.toString(), is("expected 3 results"));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description description = new StringDescription();
+        withExpectedCount(5).describeTo(description);
+        assertThat(description.toString(), is("expects 5 results"));
+    }
+
+
+    @Test
+    public void testDescribeTo2() throws Exception
+    {
+        Description description = new StringDescription();
+        withoutExpectedCount().describeTo(description);
+        assertThat(description.toString(), is("expects no specific number of results"));
+    }
+}

--- a/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/TargetMatcherTest.java
+++ b/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/TargetMatcherTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.testing.contentoperationbuilder;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class TargetMatcherTest
+{
+    @Test
+    public void testTargets() throws Exception
+    {
+        Uri dummyUri = dummy(Uri.class);
+        assertThat(targets(sameInstance(dummyUri)).matches(ContentProviderOperation.newInsert(dummyUri)), is(true));
+        assertThat(targets(sameInstance(dummyUri)).matches(ContentProviderOperation.newInsert(dummy(Uri.class))), is(false));
+    }
+
+
+    @Test
+    public void testTargets1() throws Exception
+    {
+        Uri uri = Uri.parse("http://example.org/test");
+        assertThat(targets(uri).matches(ContentProviderOperation.newInsert(uri)), is(true));
+        assertThat(targets(uri).matches(ContentProviderOperation.newInsert(Uri.parse("http://example.com"))), is(false));
+    }
+
+
+    @Test
+    public void testTargets2() throws Exception
+    {
+        assertThat(targets("http://example.org/test").matches(ContentProviderOperation.newInsert(Uri.parse("http://example.org/test"))), is(true));
+        assertThat(targets("http://example.org/test").matches(ContentProviderOperation.newInsert(Uri.parse("http://example.com"))), is(false));
+    }
+
+
+    @Test
+    public void testMatchesSafelyMismatch() throws Exception
+    {
+        Description description = new StringDescription();
+        targets("http://example.com").matchesSafely(ContentProviderOperation.newInsert(Uri.parse("http://example.org/test")), description);
+        assertThat(description.toString(), is("Operation target was <http://example.org/test>"));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description description = new StringDescription();
+        targets("http://example.com").describeTo(description);
+        assertThat(description.toString(), is("Operation target is <http://example.com>"));
+    }
+
+}

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MultiInsertBatchTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MultiInsertBatchTest.java
@@ -35,12 +35,15 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.insertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -77,18 +80,20 @@ public class MultiInsertBatchTest
     public void testSingle()
     {
         InsertOperation<Object> mockOp = mock(InsertOperation.class);
+        final Uri dummyUri = dummy(Uri.class);
         when(mockOp.contentOperationBuilder(any(TransactionContext.class))).then(new Answer<ContentProviderOperation.Builder>()
         {
             @Override
             public ContentProviderOperation.Builder answer(InvocationOnMock invocation) throws Throwable
             {
-                return ContentProviderOperation.newInsert(Uri.EMPTY);
+                return ContentProviderOperation.newInsert(dummyUri);
             }
         });
 
         assertThat(new MultiInsertBatch<>(mockOp, new CharSequenceRowData<>("key", "value")),
                 Matchers.contains(
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(containing("key", "value")),
                                 withoutExpectedCount(),
@@ -100,12 +105,14 @@ public class MultiInsertBatchTest
     public void testSingleComposite()
     {
         InsertOperation<Object> mockOp = mock(InsertOperation.class);
+        final Uri dummyUri = dummy(Uri.class);
+
         when(mockOp.contentOperationBuilder(any(TransactionContext.class))).then(new Answer<ContentProviderOperation.Builder>()
         {
             @Override
             public ContentProviderOperation.Builder answer(InvocationOnMock invocation) throws Throwable
             {
-                return ContentProviderOperation.newInsert(Uri.EMPTY);
+                return ContentProviderOperation.newInsert(dummyUri);
             }
         });
 
@@ -116,6 +123,7 @@ public class MultiInsertBatchTest
                                 new CharSequenceRowData<>("key3", "value3"))),
                 Matchers.contains(
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(
                                         containing("key", "value"),
@@ -130,12 +138,13 @@ public class MultiInsertBatchTest
     public void testMulti()
     {
         InsertOperation<Object> mockOp = mock(InsertOperation.class);
+        final Uri dummyUri = dummy(Uri.class);
         when(mockOp.contentOperationBuilder(any(TransactionContext.class))).then(new Answer<ContentProviderOperation.Builder>()
         {
             @Override
             public ContentProviderOperation.Builder answer(InvocationOnMock invocation) throws Throwable
             {
-                return ContentProviderOperation.newInsert(Uri.EMPTY);
+                return ContentProviderOperation.newInsert(dummyUri);
             }
         });
 
@@ -145,16 +154,19 @@ public class MultiInsertBatchTest
                         new CharSequenceRowData<>("key", "value3")),
                 Matchers.contains(
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(containing("key", "value")),
                                 withoutExpectedCount(),
                                 withYieldNotAllowed()),
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(containing("key", "value2")),
                                 withoutExpectedCount(),
                                 withYieldNotAllowed()),
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(containing("key", "value3")),
                                 withoutExpectedCount(),
@@ -166,12 +178,13 @@ public class MultiInsertBatchTest
     public void testMultiComposite()
     {
         InsertOperation<Object> mockOp = mock(InsertOperation.class);
+        final Uri dummyUri = dummy(Uri.class);
         when(mockOp.contentOperationBuilder(any(TransactionContext.class))).then(new Answer<ContentProviderOperation.Builder>()
         {
             @Override
             public ContentProviderOperation.Builder answer(InvocationOnMock invocation) throws Throwable
             {
-                return ContentProviderOperation.newInsert(Uri.EMPTY);
+                return ContentProviderOperation.newInsert(dummyUri);
             }
         });
 
@@ -190,6 +203,7 @@ public class MultiInsertBatchTest
                                 new CharSequenceRowData<>("key3c", "value3c"))),
                 Matchers.contains(
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(
                                         containing("key1a", "value1a"),
@@ -198,6 +212,7 @@ public class MultiInsertBatchTest
                                 withoutExpectedCount(),
                                 withYieldNotAllowed()),
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(
                                         containing("key2a", "value2a"),
@@ -206,6 +221,7 @@ public class MultiInsertBatchTest
                                 withoutExpectedCount(),
                                 withYieldNotAllowed()),
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 insertOperation(),
                                 withValuesOnly(
                                         containing("key3a", "value3a"),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/YieldableTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/YieldableTest.java
@@ -32,11 +32,15 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.updateOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -64,22 +68,25 @@ public class YieldableTest
         Operation<?> mockOp1 = mock(Operation.class);
         Operation<?> mockOp2 = mock(Operation.class);
         Operation<?> mockOp3 = mock(Operation.class);
+        Uri dummyUri = dummy(Uri.class);
 
-        doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(mockOp1).contentOperationBuilder(ArgumentMatchers.any(TransactionContext.class));
+        doReturn(ContentProviderOperation.newUpdate(dummyUri)).when(mockOp1).contentOperationBuilder(ArgumentMatchers.any(TransactionContext.class));
 
         // every last operation of each batch should allow yielding
 
         assertThat(new Yieldable(new SingletonIterable<Operation<?>>(mockOp1)),
-                Matchers.contains(
+                iteratesTo(
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 updateOperation(),
                                 withoutValues(),
                                 withoutExpectedCount(),
                                 withYieldAllowed())));
 
         assertThat(new Yieldable(new Seq<>(mockOp1, mockOp2)),
-                Matchers.contains(
+                iteratesTo(
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 updateOperation(),
                                 withoutValues(),
                                 withoutExpectedCount(),
@@ -87,8 +94,9 @@ public class YieldableTest
                         Matchers.<Operation>is(mockOp2)));
 
         assertThat(new Yieldable(new Seq<>(mockOp1, mockOp2, mockOp3)),
-                Matchers.contains(
+                iteratesTo(
                         builds(
+                                targets(sameInstance(dummyUri)),
                                 updateOperation(),
                                 withoutValues(),
                                 withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AccountScopedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AccountScopedTest.java
@@ -29,6 +29,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.insertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
@@ -63,9 +64,11 @@ public class AccountScopedTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
+        Uri dummyUri = dummy(Uri.class);
         assertThat(
-                new AccountScoped<>(new Account("name", "type"), new RawInsert<>(Uri.EMPTY)),
+                new AccountScoped<>(new Account("name", "type"), new RawInsert<>(dummyUri)),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         insertOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AssertTest.java
@@ -31,6 +31,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.assertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
@@ -38,6 +39,7 @@ import static org.dmfs.android.contentpal.testing.contentvalues.Containing.conta
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -67,10 +69,12 @@ public final class AssertTest
         RowSnapshot<Object> mockRowSnapshot = failingMock(RowSnapshot.class);
         SoftRowReference<Object> dummyRowReference = dummy(SoftRowReference.class);
         doReturn(dummyRowReference).when(mockRowSnapshot).reference();
-        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(dummyRowReference).assertOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newAssertQuery(dummyUri)).when(dummyRowReference).assertOperationBuilder(any(TransactionContext.class));
 
         assertThat(new Assert<>(mockRowSnapshot, new CharSequenceRowData<>("key", "value")),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         assertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
@@ -34,6 +34,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.assertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
@@ -43,6 +44,7 @@ import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.bu
 import static org.dmfs.android.contentpal.testing.predicates.PredicateArgumentMatcher.predicateWithSelection;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
@@ -83,11 +85,12 @@ public final class BulkAssertTest
         Operation<Object> mockAssertOperation = failingMock(Operation.class);
 
         doReturn(mockAssertOperation).when(mockTable).assertOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
-
-        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newAssertQuery(dummyUri)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkAssert<>(mockTable),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         assertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),
@@ -103,11 +106,12 @@ public final class BulkAssertTest
         Operation<Object> mockAssertOperation = failingMock(Operation.class);
 
         doReturn(mockAssertOperation).when(mockTable).assertOperation(EmptyUriParams.INSTANCE, dummyPredicate);
-
-        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newAssertQuery(dummyUri)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkAssert<>(mockTable, dummyPredicate),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         assertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),
@@ -122,11 +126,12 @@ public final class BulkAssertTest
         Operation<Object> mockAssertOperation = failingMock(Operation.class);
 
         doReturn(mockAssertOperation).when(mockTable).assertOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
-
-        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newAssertQuery(dummyUri)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkAssert<>(mockTable, new CharSequenceRowData<>("key", "value")),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         assertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),
@@ -143,11 +148,12 @@ public final class BulkAssertTest
         Operation<Object> mockAssertOperation = failingMock(Operation.class);
 
         doReturn(mockAssertOperation).when(mockTable).assertOperation(EmptyUriParams.INSTANCE, dummyPredicate);
-
-        doReturn(ContentProviderOperation.newAssertQuery(Uri.EMPTY)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newAssertQuery(dummyUri)).when(mockAssertOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkAssert<>(mockTable, new CharSequenceRowData<>("key", "value"), dummyPredicate),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         assertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
@@ -32,6 +32,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.deleteOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
@@ -39,6 +40,7 @@ import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.bu
 import static org.dmfs.android.contentpal.testing.predicates.PredicateArgumentMatcher.predicateWithSelection;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
@@ -74,11 +76,12 @@ public final class BulkDeleteTest
         Operation<Object> mockOperation = failingMock(Operation.class);
 
         doReturn(mockOperation).when(mockTable).deleteOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
-
-        doReturn(ContentProviderOperation.newDelete(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newDelete(dummyUri)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkDelete<>(mockTable),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         deleteOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),
@@ -94,11 +97,12 @@ public final class BulkDeleteTest
         Predicate dummyPredicate = mock(Predicate.class);
 
         doReturn(mockOperation).when(mockTable).deleteOperation(EmptyUriParams.INSTANCE, dummyPredicate);
-
-        doReturn(ContentProviderOperation.newDelete(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newDelete(dummyUri)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkDelete<>(mockTable, dummyPredicate),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         deleteOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
@@ -34,6 +34,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.updateOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
@@ -42,6 +43,7 @@ import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.bu
 import static org.dmfs.android.contentpal.testing.predicates.PredicateArgumentMatcher.predicateWithSelection;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
@@ -77,10 +79,12 @@ public final class BulkUpdateTest
 
         doReturn(mockOperation).when(mockTable).updateOperation(same(EmptyUriParams.INSTANCE), predicateWithSelection("1"));
 
-        doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newUpdate(dummyUri)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkUpdate<>(mockTable, new CharSequenceRowData<>("key", "value")),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         updateOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),
@@ -98,10 +102,12 @@ public final class BulkUpdateTest
 
         doReturn(mockOperation).when(mockTable).updateOperation(EmptyUriParams.INSTANCE, dummyPredicate);
 
-        doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newUpdate(dummyUri)).when(mockOperation).contentOperationBuilder(any(TransactionContext.class));
 
         assertThat(new BulkUpdate<>(mockTable, new CharSequenceRowData<>("key", "value"), dummyPredicate),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         updateOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/CountedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/CountedTest.java
@@ -28,6 +28,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.updateOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
@@ -37,7 +38,6 @@ import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 
 
 /**
@@ -61,9 +61,11 @@ public class CountedTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
+        Uri dummyUri = dummy(Uri.class);
         assertThat(
-                new Counted<>(10, new RawUpdate<>(mock(Uri.class))),
+                new Counted<>(10, new RawUpdate<>(dummyUri)),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         updateOperation(),
                         withYieldNotAllowed(),
                         withExpectedCount(10),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DeleteTest.java
@@ -29,12 +29,14 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.deleteOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -62,11 +64,13 @@ public class DeleteTest
         RowSnapshot<Object> mockRowSnapshot = failingMock(RowSnapshot.class);
         SoftRowReference<Object> rowReference = failingMock(SoftRowReference.class);
         doReturn(rowReference).when(mockRowSnapshot).reference();
-        doReturn(ContentProviderOperation.newDelete(Uri.EMPTY)).when(rowReference).deleteOperationBuilder(any(TransactionContext.class));
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(ContentProviderOperation.newDelete(dummyUri)).when(rowReference).deleteOperationBuilder(any(TransactionContext.class));
 
         assertThat(
                 new Delete<>(mockRowSnapshot),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         deleteOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/InsertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/InsertTest.java
@@ -31,6 +31,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.insertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
@@ -39,6 +40,7 @@ import static org.dmfs.android.contentpal.testing.contentvalues.Containing.conta
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
@@ -67,10 +69,12 @@ public class InsertTest
     public void testContentOperationBuilder() throws Exception
     {
         Table<Object> mockTable = failingMock(Table.class);
-        doReturn(new RawInsert<>(dummy(Uri.class))).when(mockTable).insertOperation(EmptyUriParams.INSTANCE);
+        Uri dummyUri = dummy(Uri.class);
+        doReturn(new RawInsert<>(dummyUri)).when(mockTable).insertOperation(EmptyUriParams.INSTANCE);
 
         assertThat(new Insert<>(mockTable),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         insertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),
@@ -78,6 +82,7 @@ public class InsertTest
 
         assertThat(new Insert<>(mockTable, new CharSequenceRowData<>("key", "value")),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         insertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PopulatedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PopulatedTest.java
@@ -29,6 +29,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.insertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
@@ -63,9 +64,11 @@ public class PopulatedTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
+        Uri dummyUri = dummy(Uri.class);
         assertThat(
-                new Populated<>(new CharSequenceRowData<>("a", "x"), new RawInsert<>(Uri.EMPTY)),
+                new Populated<>(new CharSequenceRowData<>("a", "x"), new RawInsert<>(dummyUri)),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         insertOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PutTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PutTest.java
@@ -29,6 +29,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.updateOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
@@ -71,11 +72,13 @@ public class PutTest
         RowSnapshot<Object> mockRowSnapshot = failingMock(RowSnapshot.class);
         SoftRowReference<Object> mockRowReference = failingMock(SoftRowReference.class);
 
+        Uri dummyUri = dummy(Uri.class);
         doReturn(mockRowReference).when(mockRowSnapshot).reference();
-        doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(mockRowReference).putOperationBuilder(any(TransactionContext.class));
+        doReturn(ContentProviderOperation.newUpdate(dummyUri)).when(mockRowReference).putOperationBuilder(any(TransactionContext.class));
 
         assertThat(new Put<>(mockRowSnapshot),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         updateOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),
@@ -91,11 +94,13 @@ public class PutTest
         RowSnapshot<Object> mockRowSnapshot = failingMock(RowSnapshot.class);
         SoftRowReference<Object> mockRowReference = failingMock(SoftRowReference.class);
 
+        Uri dummyUri = dummy(Uri.class);
         doReturn(mockRowReference).when(mockRowSnapshot).reference();
-        doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(mockRowReference).putOperationBuilder(any(TransactionContext.class));
+        doReturn(ContentProviderOperation.newUpdate(dummyUri)).when(mockRowReference).putOperationBuilder(any(TransactionContext.class));
 
         assertThat(new Put<>(mockRowSnapshot, new CharSequenceRowData<>("x", "y")),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         updateOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/ReferringTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/ReferringTest.java
@@ -30,6 +30,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.insertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
@@ -38,6 +39,7 @@ import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.bu
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
@@ -67,8 +69,10 @@ public class ReferringTest
         RowSnapshot<Object> mockSnapshot = failingMock(RowSnapshot.class);
         doReturn(new RowUriReference<>(Uri.parse("content://abc/xyz/123"))).when(mockSnapshot).reference();
 
-        assertThat(new Referring<>(mockSnapshot, "column", new RawInsert<>(dummy(Uri.class))),
+        Uri dummyUri = dummy(Uri.class);
+        assertThat(new Referring<>(mockSnapshot, "column", new RawInsert<>(dummyUri)),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         insertOperation(),
                         withoutExpectedCount(),
                         withYieldNotAllowed(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/YieldableTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/YieldableTest.java
@@ -28,6 +28,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.insertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldAllowed;
@@ -61,9 +62,11 @@ public class YieldableTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
+        Uri dummyUri = dummy(Uri.class);
         assertThat(
-                new Yieldable<>(new RawInsert<>(Uri.EMPTY)),
+                new Yieldable<>(new RawInsert<>(dummyUri)),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         insertOperation(),
                         withYieldAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawAssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawAssertTest.java
@@ -26,11 +26,13 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.assertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
 
@@ -51,8 +53,10 @@ public class RawAssertTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
-        assertThat(new RawAssert<>(dummy(Uri.class)),
+        Uri dummyUri = dummy(Uri.class);
+        assertThat(new RawAssert<>(dummyUri),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         assertOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawDeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawDeleteTest.java
@@ -26,11 +26,13 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.deleteOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
 
@@ -51,8 +53,10 @@ public class RawDeleteTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
-        assertThat(new RawDelete<>(dummy(Uri.class)),
+        Uri dummyUri = dummy(Uri.class);
+        assertThat(new RawDelete<>(dummyUri),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         deleteOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawInsertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawInsertTest.java
@@ -26,11 +26,13 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.insertOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
 
@@ -51,8 +53,10 @@ public class RawInsertTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
-        assertThat(new RawInsert<>(dummy(Uri.class)),
+        Uri dummyUri = dummy(Uri.class);
+        assertThat(new RawInsert<>(dummyUri),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         insertOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawUpdateTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawUpdateTest.java
@@ -26,11 +26,13 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.OperationType.updateOperation;
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.TargetMatcher.targets;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithExpectedCount.withoutExpectedCount;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
 
@@ -51,8 +53,10 @@ public class RawUpdateTest
     @Test
     public void testContentOperationBuilder() throws Exception
     {
-        assertThat(new RawUpdate<>(dummy(Uri.class)),
+        Uri dummyUri = dummy(Uri.class);
+        assertThat(new RawUpdate<>(dummyUri),
                 builds(
+                        targets(sameInstance(dummyUri)),
                         updateOperation(),
                         withYieldNotAllowed(),
                         withoutExpectedCount(),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/projections/CompositeTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/projections/CompositeTest.java
@@ -44,6 +44,15 @@ public class CompositeTest
     @Test
     public void testNonEmpty() throws Exception
     {
+        // test vararg ctor
+        assertThat(new Composite<>(new MultiProjection<Contract>("abc")), projects("abc"));
+        assertThat(new Composite<>(new MultiProjection<Contract>("abc", "xyz", "qrs")), projects("abc", "xyz", "qrs"));
+        assertThat(new Composite<>(new MultiProjection<Contract>("abc"), new MultiProjection<Contract>("xyz")), projects("abc", "xyz"));
+        assertThat(new Composite<>(new MultiProjection<Contract>("abc", "xyz", "qrs")), projects("abc", "xyz", "qrs"));
+        assertThat(new Composite<>(new MultiProjection<Contract>("abc", "xyz", "qrs"), new MultiProjection<Contract>("123", "456", "789")),
+                projects("abc", "xyz", "qrs", "123", "456", "789"));
+
+        // test iterable ctor
         assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc"))), projects("abc"));
         assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc", "xyz", "qrs"))), projects("abc", "xyz", "qrs"));
         assertThat(new Composite<>(new Seq<Projection<Contract>>(new MultiProjection<Contract>("abc"), new MultiProjection<Contract>("xyz"))),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/tools/OperationSizeTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/tools/OperationSizeTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.tools;
+
+import android.content.ContentProviderOperation;
+import android.net.Uri;
+
+import org.dmfs.android.contentpal.operations.BulkUpdate;
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.rowdata.Composite;
+import org.dmfs.android.contentpal.tables.BaseTable;
+import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.hamcrest.CoreMatchers.both;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class OperationSizeTest
+{
+    @Test
+    public void testConsitency()
+    {
+        // test that all Number methods return the same value
+        int expected = new OperationSize(
+                new BulkUpdate<>(
+                        new BaseTable<>(Uri.parse("content://authority")),
+                        new CharSequenceRowData<>("key", "012345678901234567890123456789"))
+                        .contentOperationBuilder(new EmptyTransactionContext())
+                        .build())
+                .intValue();
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.parse("content://authority")),
+                                new CharSequenceRowData<>("key", "012345678901234567890123456789"))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .floatValue(),
+                is((float) expected));
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.parse("content://authority")),
+                                new CharSequenceRowData<>("key", "012345678901234567890123456789"))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .longValue(),
+                is((long) expected));
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.parse("content://authority")),
+                                new CharSequenceRowData<>("key", "012345678901234567890123456789"))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .doubleValue(),
+                is((double) expected));
+    }
+
+
+    /**
+     * This test ensures a "plausible" size of an operation.
+     * <p>
+     * Unfortunately, there is no reliable way of calculating the exact size of data sent when executing a {@link ContentProviderOperation}. The exact value
+     * depends on implementation details which may vary on different platforms or platform versions.
+     * <p>
+     * Even under the assumption that the data is ultimately parcelled when doing the actual IPC, there are still unknown variables, like the exact number and
+     * size of fields being parcelled and the actual parcel format.
+     * <p>
+     * To account for these unknown parameters we test if the size is within certain bounds which are expected to grow in a way that's somehow proportional to
+     * the data we put into the operation. So under the assumption there is minimum size for an operation which only updates an empty string, we expect that the
+     * size grows when we add more fields.
+     * <p>
+     * This test is by far not perfect any may have to be adjusted when exectued on new platforms.
+     */
+    @Test
+    public void testPlausibility()
+    {
+        // minimal operation:
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.EMPTY), new CharSequenceRowData<>("", ""))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .intValue(),
+                is(both(greaterThan(70)).and(lessThan(120))));
+
+        //  minimal operation + 40 characters of data
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.EMPTY), new CharSequenceRowData<>("a1234567890123456789", "01234567890123456789"))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .intValue(),
+                is(both(greaterThan(70 + 40)).and(lessThan(120 + 40 + 8))));
+
+        //  minimal operation + 80 characters of data
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.EMPTY),
+                                new Composite<>(
+                                        new CharSequenceRowData<>("a1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("b1234567890123456789", "01234567890123456789")))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .intValue(),
+                is(both(greaterThan(70 + 80)).and(lessThan(120 + 80 + 16))));
+        //  minimal operation + 160 characters of data
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.EMPTY),
+                                new Composite<>(
+                                        new CharSequenceRowData<>("a1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("b1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("c1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("d1234567890123456789", "01234567890123456789")))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .intValue(),
+                is(both(greaterThan(70 + 160)).and(lessThan(120 + 160 + 32))));
+        //  minimal operation + 320 characters of data
+        assertThat(
+                new OperationSize(
+                        new BulkUpdate<>(
+                                new BaseTable<>(Uri.EMPTY),
+                                new Composite<>(
+                                        new CharSequenceRowData<>("a1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("b1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("c1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("d1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("e1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("f1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("g1234567890123456789", "01234567890123456789"),
+                                        new CharSequenceRowData<>("h1234567890123456789", "01234567890123456789")))
+                                .contentOperationBuilder(new EmptyTransactionContext())
+                                .build())
+                        .intValue(),
+                is(both(greaterThan(70 + 320)).and(lessThan(120 + 320 + 64))));
+    }
+
+}


### PR DESCRIPTION
This also adds a hamcrest matcher to match the target uri of a ContentProviderOperation and updates all existing tests to check the URI as well.