### PR TITLE
Split AttendeeData into smaller classes, implements #166

### DIFF
--- a/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
+++ b/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
@@ -32,6 +32,9 @@ import android.util.Log;
 import android.view.View;
 
 import org.dmfs.android.calendarpal.attendees.AttendeeData;
+import org.dmfs.android.calendarpal.attendees.NameData;
+import org.dmfs.android.calendarpal.attendees.StateData;
+import org.dmfs.android.calendarpal.attendees.TypeData;
 import org.dmfs.android.calendarpal.calendars.Colored;
 import org.dmfs.android.calendarpal.calendars.Named;
 import org.dmfs.android.calendarpal.calendars.Synced;
@@ -306,9 +309,17 @@ public class DemoActivity extends AppCompatActivity
                         // add an attendee to event2
                         new EventRelated<>(event2,
                                 new Insert<>(new Attendees(),
-                                        new org.dmfs.android.calendarpal.attendees.Named("Me", new AttendeeData("me@example.com")))),
+                                        new AttendeeData("me@example.com", new NameData("me")))),
                         // add a reminder to event2, one day in advance
-                        new EventRelated<>(event2, new Insert<>(new Reminders(), new ReminderData((int) TimeUnit.DAYS.toMinutes(1))))
+                        new EventRelated<>(event2, new Insert<>(new Reminders(), new ReminderData((int) TimeUnit.DAYS.toMinutes(1)))),
+                        new EventRelated<>(event2, new Insert<>(new Attendees(),
+                                new AttendeeData("metoo@example.com",
+                                        new Composite<>(
+                                                new NameData("Me Too"),
+                                                new TypeData(CalendarContract.Attendees.TYPE_REQUIRED),
+                                                new org.dmfs.android.calendarpal.attendees.RelationData(CalendarContract.Attendees.RELATIONSHIP_ORGANIZER),
+                                                new StateData(CalendarContract.Attendees.STATUS_CONFIRMED)
+                                        ))))
 
                         //new Put<>(new VirtualRowSnapshot<>(calendarEvents), new )
                 ));

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/EmailData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/EmailData.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.content.ContentProviderOperation;
+import android.provider.CalendarContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
+
+
+/**
+ * {@link CalendarContract.Attendees} {@link RowData} which sets the {@link CalendarContract.Attendees#ATTENDEE_EMAIL} of an attendee.
+ * <p>
+ * This is meant for internal use only. Users of this library should not update the email of an attendee but instead delete the old one and insert a new one
+ * with {@link AttendeeData}.
+ *
+ * @author Marten Gajda
+ */
+public final class EmailData implements RowData<CalendarContract.Attendees>
+{
+    private final CharSequence mEmail;
+
+
+    public EmailData(@NonNull CharSequence email)
+    {
+        mEmail = email;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
+    {
+        return builder.withValue(CalendarContract.Attendees.ATTENDEE_EMAIL, mEmail.toString());
+    }
+}

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/NameData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/NameData.java
@@ -26,28 +26,25 @@ import org.dmfs.android.contentpal.TransactionContext;
 
 
 /**
- * {@link CalendarContract.Attendees} {@link RowData} decorator which adds a name to an attendee.
+ * {@link CalendarContract.Attendees} {@link RowData} which sets the {@link CalendarContract.Attendees#ATTENDEE_NAME} of an attendee.
  *
  * @author Marten Gajda
  */
-public final class Named implements RowData<CalendarContract.Attendees>
+public final class NameData implements RowData<CalendarContract.Attendees>
 {
-    private final RowData<CalendarContract.Attendees> mDelegate;
     private final CharSequence mName;
 
 
-    public Named(@Nullable CharSequence name, @NonNull RowData<CalendarContract.Attendees> delegate)
+    public NameData(@Nullable CharSequence name)
     {
-        mDelegate = delegate;
         mName = name;
     }
 
 
     @NonNull
     @Override
-    public ContentProviderOperation.Builder updatedBuilder(TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
     {
-        return mDelegate.updatedBuilder(transactionContext, builder)
-                .withValue(CalendarContract.Attendees.ATTENDEE_NAME, mName == null ? null : mName.toString());
+        return builder.withValue(CalendarContract.Attendees.ATTENDEE_NAME, mName == null ? null : mName.toString());
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/RelationData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/RelationData.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.content.ContentProviderOperation;
+import android.provider.CalendarContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
+
+
+/**
+ * {@link CalendarContract.Attendees} {@link RowData} which sets the {@link CalendarContract.Attendees#ATTENDEE_RELATIONSHIP} of an attendee.
+ *
+ * @author Marten Gajda
+ */
+public final class RelationData implements RowData<CalendarContract.Attendees>
+{
+    private final int mRelationship;
+
+
+    public RelationData(int relationship)
+    {
+        mRelationship = relationship;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
+    {
+        return builder.withValue(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, mRelationship);
+    }
+}

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/StateData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/StateData.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.content.ContentProviderOperation;
+import android.provider.CalendarContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
+
+
+/**
+ * {@link CalendarContract.Attendees} {@link RowData} which sets the {@link CalendarContract.Attendees#ATTENDEE_STATUS} of an attendee.
+ *
+ * @author Marten Gajda
+ */
+public final class StateData implements RowData<CalendarContract.Attendees>
+{
+    private final int mState;
+
+
+    public StateData(int state)
+    {
+        mState = state;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
+    {
+        return builder.withValue(CalendarContract.Attendees.ATTENDEE_STATUS, mState);
+    }
+}

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/TypeData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/attendees/TypeData.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.content.ContentProviderOperation;
+import android.provider.CalendarContract;
+import android.support.annotation.NonNull;
+
+import org.dmfs.android.contentpal.RowData;
+import org.dmfs.android.contentpal.TransactionContext;
+
+
+/**
+ * {@link CalendarContract.Attendees} {@link RowData} which sets the {@link CalendarContract.Attendees#ATTENDEE_TYPE} of an attendee.
+ *
+ * @author Marten Gajda
+ */
+public final class TypeData implements RowData<CalendarContract.Attendees>
+{
+    private final int mType;
+
+
+    public TypeData(int type)
+    {
+        mType = type;
+    }
+
+
+    @NonNull
+    @Override
+    public ContentProviderOperation.Builder updatedBuilder(@NonNull TransactionContext transactionContext, @NonNull ContentProviderOperation.Builder builder)
+    {
+        return builder.withValue(CalendarContract.Attendees.ATTENDEE_TYPE, mType);
+    }
+}

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/AttendeeDataTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/AttendeeDataTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.provider.CalendarContract;
+
+import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
+import org.dmfs.android.contentpal.rowdata.Composite;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test {@link AttendeeData}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class AttendeeDataTest
+{
+    @Test
+    public void testUpdatedBuilder() throws Exception
+    {
+        // without any attributes this sets email and defaults
+        assertThat(new AttendeeData("xyz"), builds(
+                withValuesOnly(
+                        containing(CalendarContract.Attendees.ATTENDEE_EMAIL, "xyz"),
+                        containing(CalendarContract.Attendees.ATTENDEE_TYPE, CalendarContract.Attendees.TYPE_NONE),
+                        containing(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, CalendarContract.Attendees.RELATIONSHIP_NONE),
+                        containing(CalendarContract.Attendees.ATTENDEE_STATUS, CalendarContract.Attendees.ATTENDEE_STATUS_NONE)
+                )));
+    }
+
+
+    @Test
+    public void testUpdatedBuilderAttributes() throws Exception
+    {
+        // attributes should be added too
+        assertThat(new AttendeeData("xyz", new CharSequenceRowData<>("test", "value")), builds(
+                withValuesOnly(
+                        containing(CalendarContract.Attendees.ATTENDEE_EMAIL, "xyz"),
+                        containing(CalendarContract.Attendees.ATTENDEE_TYPE, CalendarContract.Attendees.TYPE_NONE),
+                        containing(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, CalendarContract.Attendees.RELATIONSHIP_NONE),
+                        containing(CalendarContract.Attendees.ATTENDEE_STATUS, CalendarContract.Attendees.ATTENDEE_STATUS_NONE),
+                        containing("test", "value")
+                )));
+    }
+
+
+    @Test
+    public void testUpdatedBuilderOverrides() throws Exception
+    {
+        // overrides should be kept
+        assertThat(new AttendeeData("xyz", new Composite<CalendarContract.Attendees>(
+                        new CharSequenceRowData<>(CalendarContract.Attendees.ATTENDEE_TYPE, "type"),
+                        new CharSequenceRowData<>(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, "rel"),
+                        new CharSequenceRowData<>(CalendarContract.Attendees.ATTENDEE_STATUS, "stat"),
+                        new CharSequenceRowData<>("test", "value")
+                )),
+                builds(
+                        withValuesOnly(
+                                containing(CalendarContract.Attendees.ATTENDEE_EMAIL, "xyz"),
+                                containing(CalendarContract.Attendees.ATTENDEE_TYPE, "type"),
+                                containing(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, "rel"),
+                                containing(CalendarContract.Attendees.ATTENDEE_STATUS, "stat"),
+                                containing("test", "value")
+                        )));
+    }
+
+}

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/EmailDataTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/EmailDataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.provider.CalendarContract;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link EmailData}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class EmailDataTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new EmailData("xyz"), builds(
+                withValuesOnly(
+                        containing(CalendarContract.Attendees.ATTENDEE_EMAIL, "xyz")
+                )));
+    }
+
+}

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/NameDataTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/NameDataTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.provider.CalendarContract;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.contentvalues.NullValue.withNullValue;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link NameData}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class NameDataTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new NameData("xyz"), builds(
+                withValuesOnly(
+                        containing(CalendarContract.Attendees.ATTENDEE_NAME, "xyz")
+                )));
+
+        assertThat(new NameData(null), builds(
+                withValuesOnly(
+                        withNullValue(CalendarContract.Attendees.ATTENDEE_NAME)
+                )));
+    }
+
+}

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/RelationDataTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/RelationDataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.provider.CalendarContract;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link RelationData}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class RelationDataTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new RelationData(1234), builds(
+                withValuesOnly(
+                        containing(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP, 1234)
+                )));
+    }
+
+}

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/StateDataTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/StateDataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.provider.CalendarContract;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link StateData}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class StateDataTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new StateData(1234), builds(
+                withValuesOnly(
+                        containing(CalendarContract.Attendees.ATTENDEE_STATUS, 1234)
+                )));
+    }
+
+}

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/TypeDataTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/attendees/TypeDataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.calendarpal.attendees;
+
+import android.provider.CalendarContract;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withValuesOnly;
+import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
+import static org.dmfs.android.contentpal.testing.rowdata.RowDataMatcher.builds;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link TypeData}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class TypeDataTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new TypeData(1234), builds(
+                withValuesOnly(
+                        containing(CalendarContract.Attendees.ATTENDEE_TYPE, 1234)
+                )));
+    }
+
+}


### PR DESCRIPTION
This commit splits `AttendeeData` into smaller, more SRP-ish classes. Now there is a class for each attendee value.

Note, `AttendeeData` still sets the required defaults of the attendde relationship, status and type. They can be overridden by supplying an attributes `RowData<Attendees>` object.