### PR TITLE
Replace deprecated classes. Implements #169

### DIFF
--- a/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
+++ b/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
@@ -96,9 +96,9 @@ import org.dmfs.android.contentpal.rowdata.Composite;
 import org.dmfs.android.contentpal.rowsnapshots.VirtualRowSnapshot;
 import org.dmfs.android.contentpal.tables.AccountScoped;
 import org.dmfs.iterables.SingletonIterable;
-import org.dmfs.iterables.decorators.Flattened;
 import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.function.elementary.IdentityFunction;
+import org.dmfs.jems.iterable.composite.Joined;
+import org.dmfs.jems.single.combined.Backed;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 
@@ -215,7 +215,7 @@ public class DemoActivity extends AppCompatActivity
 
         // insert the contact and link it to the first one in the same transaction
         mContactsQueue.enqueue(
-                new Flattened<>(
+                new Joined<>(
                         new InsertRawContactBatch(rawContact2,
                                 new DisplayNameData("Donald Duck"),
                                 new Typed(ContactsContract.CommonDataKinds.Phone.TYPE_WORK, new PhoneData("9876"))
@@ -240,7 +240,7 @@ public class DemoActivity extends AppCompatActivity
             RowDataSnapshot<?> values = row.values();
             for (String key : values)
             {
-                Log.v("ContentPal Demo", String.format("%s: %s", key, values.data(key, new IdentityFunction<String>()).value("")));
+                Log.v("ContentPal Demo", String.format("%s: %s", key, new Backed<>(values.data(key, x -> x), "").value()));
             }
         }
 

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/RecurringEventData.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/events/RecurringEventData.java
@@ -25,8 +25,8 @@ import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.SingletonIterable;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
+import org.dmfs.jems.function.Function;
+import org.dmfs.jems.iterable.decorators.Mapped;
 import org.dmfs.rfc5545.DateTime;
 import org.dmfs.rfc5545.Duration;
 import org.dmfs.rfc5545.recur.RecurrenceRule;
@@ -46,14 +46,7 @@ public final class RecurringEventData implements RowData<CalendarContract.Events
     private final Iterable<DateTime> mExDates;
     private final Iterable<DateTime> mRDates;
 
-    private Function<DateTime, DateTime> mUtcDate = new Function<DateTime, DateTime>()
-    {
-        @Override
-        public DateTime apply(DateTime argument)
-        {
-            return argument.shiftTimeZone(DateTime.UTC);
-        }
-    };
+    private final Function<DateTime, DateTime> mUtcDate = argument -> argument.shiftTimeZone(DateTime.UTC);
 
 
     public RecurringEventData(@NonNull CharSequence title, @NonNull DateTime start, @NonNull Duration duration, @NonNull RecurrenceRule rule)
@@ -107,8 +100,8 @@ public final class RecurringEventData implements RowData<CalendarContract.Events
                 .withValue(CalendarContract.Events.DURATION, mDuration.toString())
                 .withValue(CalendarContract.Events.TITLE, mTitle.toString())
                 .withValue(CalendarContract.Events.RRULE, TextUtils.join("\n", mRules))
-                .withValue(CalendarContract.Events.RDATE, TextUtils.join(",", new Mapped<>(mRDates, mUtcDate)))
-                .withValue(CalendarContract.Events.EXDATE, TextUtils.join(",", new Mapped<>(mExDates, mUtcDate)))
+                .withValue(CalendarContract.Events.RDATE, TextUtils.join(",", new Mapped<>(mUtcDate, mRDates)))
+                .withValue(CalendarContract.Events.EXDATE, TextUtils.join(",", new Mapped<>(mUtcDate, mExDates)))
                 // explicitly (re-)set DTEND to null
                 .withValue(CalendarContract.Events.DTEND, null)
                 .withValue(CalendarContract.Events.EVENT_END_TIMEZONE, null);

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/CalendarEvent.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/CalendarEvent.java
@@ -30,7 +30,7 @@ import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.Insert;
 import org.dmfs.android.contentpal.operations.Referring;
 import org.dmfs.android.contentpal.tables.Synced;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/EventRelated.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/EventRelated.java
@@ -26,7 +26,7 @@ import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.Referring;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/TransientEventsCleanup.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/operations/TransientEventsCleanup.java
@@ -28,7 +28,7 @@ import org.dmfs.android.contentpal.operations.BulkDelete;
 import org.dmfs.android.contentpal.predicates.AllOf;
 import org.dmfs.android.contentpal.predicates.EqArg;
 import org.dmfs.android.contentpal.predicates.IsNull;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/CalendarScoped.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/CalendarScoped.java
@@ -29,7 +29,7 @@ import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/predicates/CalendarScopedPredicateTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/predicates/CalendarScopedPredicateTest.java
@@ -24,16 +24,17 @@ import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.predicates.EqArg;
 import org.dmfs.android.contentpal.references.BackReference;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.argumentValues;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.backReferences;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.predicateWith;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.selection;
-import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
@@ -60,7 +61,7 @@ public final class CalendarScopedPredicateTest
                 predicateWith(
                         selection(mockTc, "( x = ? ) and ( calendar_id = ? )"),
                         argumentValues(mockTc, "y", "-1"),
-                        backReferences(mockTc, AbsentMatcher.<Integer>isAbsent(), isPresent(12))
+                        backReferences(mockTc, is(absent()), is(present(12)))
                 ));
     }
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationException.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationException.java
@@ -27,8 +27,8 @@ import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.predicates.AnyOf;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
 
 
 /**

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkLinkBatch.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkLinkBatch.java
@@ -23,8 +23,7 @@ import org.dmfs.android.contactspal.aggregation.Link;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowReference;
 import org.dmfs.iterables.decorators.DelegatingIterable;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
+import org.dmfs.jems.iterable.decorators.Mapped;
 
 
 /**
@@ -37,15 +36,7 @@ public final class BulkLinkBatch extends DelegatingIterable<Operation<?>>
 
     public BulkLinkBatch(@NonNull final RowReference<ContactsContract.RawContacts> rawContact, @NonNull Iterable<RowReference<ContactsContract.RawContacts>> linked)
     {
-        super(new Mapped<>(linked, new Function<RowReference<ContactsContract.RawContacts>, Operation<?>>()
-        {
-
-            @Override
-            public Operation<?> apply(RowReference<ContactsContract.RawContacts> rawContactsRowReference)
-            {
-                return new Link(rawContact, rawContactsRowReference);
-            }
-        }));
+        super(new Mapped<>(rawContactsRowReference -> new Link(rawContact, rawContactsRowReference), linked));
     }
 
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkSplitBatch.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/batches/BulkSplitBatch.java
@@ -23,8 +23,7 @@ import org.dmfs.android.contactspal.aggregation.Split;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowReference;
 import org.dmfs.iterables.decorators.DelegatingIterable;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
+import org.dmfs.jems.iterable.decorators.Mapped;
 
 
 /**
@@ -37,15 +36,7 @@ public final class BulkSplitBatch extends DelegatingIterable<Operation<?>>
 
     public BulkSplitBatch(@NonNull final RowReference<ContactsContract.RawContacts> rawContact, @NonNull Iterable<RowReference<ContactsContract.RawContacts>> linked)
     {
-        super(new Mapped<>(linked, new Function<RowReference<ContactsContract.RawContacts>, Operation<?>>()
-        {
-
-            @Override
-            public Operation<?> apply(RowReference<ContactsContract.RawContacts> rawContactsRowReference)
-            {
-                return new Split(rawContact, rawContactsRowReference);
-            }
-        }));
+        super(new Mapped<>(rawContactsRowReference -> new Split(rawContact, rawContactsRowReference), linked));
     }
 
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/batches/InsertRawContactBatch.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/batches/InsertRawContactBatch.java
@@ -29,10 +29,10 @@ import org.dmfs.android.contentpal.batches.MultiInsertBatch;
 import org.dmfs.android.contentpal.operations.Put;
 import org.dmfs.android.contentpal.rowsnapshots.VirtualRowSnapshot;
 import org.dmfs.android.contentpal.tables.AccountScoped;
-import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.iterables.decorators.DelegatingIterable;
-import org.dmfs.iterables.decorators.Flattened;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.composite.Joined;
 
 
 /**
@@ -51,7 +51,7 @@ public final class InsertRawContactBatch extends DelegatingIterable<Operation<?>
      */
     public InsertRawContactBatch(Account account, RowData<ContactsContract.Data>... contactData)
     {
-        this(account, new ArrayIterable<>(contactData));
+        this(account, new Seq<>(contactData));
     }
 
 
@@ -75,7 +75,7 @@ public final class InsertRawContactBatch extends DelegatingIterable<Operation<?>
      */
     public InsertRawContactBatch(Table<ContactsContract.RawContacts> rawContacts, RowData<ContactsContract.Data>... contactData)
     {
-        this(rawContacts, new ArrayIterable<>(contactData));
+        this(rawContacts, new Seq<>(contactData));
     }
 
 
@@ -99,7 +99,7 @@ public final class InsertRawContactBatch extends DelegatingIterable<Operation<?>
      */
     public InsertRawContactBatch(RowSnapshot<ContactsContract.RawContacts> rawContact, RowData<ContactsContract.Data>... contactData)
     {
-        this(rawContact, new ArrayIterable<>(contactData));
+        this(rawContact, new Seq<>(contactData));
     }
 
 
@@ -111,7 +111,7 @@ public final class InsertRawContactBatch extends DelegatingIterable<Operation<?>
      */
     public InsertRawContactBatch(RowSnapshot<ContactsContract.RawContacts> rawContact, Iterable<RowData<ContactsContract.Data>> contactData)
     {
-        super(new Flattened<>(
+        super(new Joined<>(
                 new SingletonIterable<Operation<?>>(
                         new Put<>(rawContact)),
                 new MultiInsertBatch<>(

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/WorkOrganization.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/organization/WorkOrganization.java
@@ -24,7 +24,7 @@ import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.elementary.Seq;
 
 
 /**
@@ -45,7 +45,7 @@ public final class WorkOrganization implements OrganizationData
 
     public WorkOrganization(@NonNull OrganizationData... data)
     {
-        this(new ArrayIterable<>(data));
+        this(new Seq<>(data));
     }
 
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/HomePostal.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/HomePostal.java
@@ -24,7 +24,7 @@ import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.elementary.Seq;
 
 
 /**
@@ -45,7 +45,7 @@ public final class HomePostal implements StructuredPostalData
 
     public HomePostal(@NonNull StructuredPostalData... data)
     {
-        this(new ArrayIterable<>(data));
+        this(new Seq<>(data));
     }
 
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/WorkPostal.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/data/postal/WorkPostal.java
@@ -24,7 +24,7 @@ import org.dmfs.android.contactspal.data.Typed;
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.Composite;
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.elementary.Seq;
 
 
 /**
@@ -45,7 +45,7 @@ public final class WorkPostal implements StructuredPostalData
 
     public WorkPostal(@NonNull StructuredPostalData... data)
     {
-        this(new ArrayIterable<>(data));
+        this(new Seq<>(data));
     }
 
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/operations/LocalAccountScoped.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/operations/LocalAccountScoped.java
@@ -23,7 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/operations/RawContactData.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/operations/RawContactData.java
@@ -29,7 +29,7 @@ import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.Insert;
 import org.dmfs.android.contentpal.operations.Referring;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/operations/TransientRawContactCleanup.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/operations/TransientRawContactCleanup.java
@@ -28,7 +28,7 @@ import org.dmfs.android.contentpal.operations.BulkDelete;
 import org.dmfs.android.contentpal.predicates.AllOf;
 import org.dmfs.android.contentpal.predicates.EqArg;
 import org.dmfs.android.contentpal.predicates.IsNull;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/views/Local.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/views/Local.java
@@ -29,7 +29,7 @@ import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.predicates.AllOf;
 import org.dmfs.android.contentpal.predicates.IsNull;
 import org.dmfs.android.contentpal.tables.AccountScoped;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/Operation.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/Operation.java
@@ -19,7 +19,7 @@ package org.dmfs.android.contentpal;
 import android.content.ContentProviderOperation;
 import android.support.annotation.NonNull;
 
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/Predicate.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/Predicate.java
@@ -18,7 +18,7 @@ package org.dmfs.android.contentpal;
 
 import android.support.annotation.NonNull;
 
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/RowDataSnapshot.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/RowDataSnapshot.java
@@ -19,7 +19,7 @@ package org.dmfs.android.contentpal;
 import android.support.annotation.NonNull;
 
 import org.dmfs.jems.function.Function;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**
@@ -38,7 +38,8 @@ public interface RowDataSnapshot<Contract> extends Iterable<String>
     /**
      * Returns any value assigned to the given key.
      * <p>
-     * If there is no value, it returns absent, otherwise it uses the given <code>mapFunction</code> to map from the stored String value to <code>ValueType</code>.
+     * If there is no value, it returns absent, otherwise it uses the given <code>mapFunction</code> to map from the stored String value to
+     * <code>ValueType</code>.
      */
     @NonNull
     <ValueType> Optional<ValueType> data(@NonNull String key, @NonNull Function<String, ValueType> mapFunction);

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/View.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/View.java
@@ -22,7 +22,7 @@ import android.net.Uri;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
 
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/WithExpectedCount.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/WithExpectedCount.java
@@ -19,15 +19,16 @@ package org.dmfs.android.contentpal.testing.contentoperationbuilder;
 import android.content.ContentProviderOperation;
 
 import org.dmfs.android.contentpal.testing.tools.Field;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.NullSafe;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.Present;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.NullSafe;
+import org.dmfs.jems.optional.elementary.Present;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Locale;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -55,13 +56,13 @@ public final class WithExpectedCount extends TypeSafeDiagnosingMatcher<ContentPr
 
     public WithExpectedCount()
     {
-        this(Absent.<Integer>absent());
+        this(absent());
     }
 
 
     public WithExpectedCount(int expectedCount)
     {
-        this(new Present<Integer>(expectedCount));
+        this(new Present<>(expectedCount));
     }
 
 

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/WithValues.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/contentoperationbuilder/WithValues.java
@@ -20,7 +20,8 @@ import android.content.ContentProviderOperation;
 import android.content.ContentValues;
 
 import org.dmfs.android.contentpal.testing.tools.Field;
-import org.dmfs.optional.NullSafe;
+import org.dmfs.jems.optional.elementary.NullSafe;
+import org.dmfs.jems.single.combined.Backed;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -61,7 +62,7 @@ public final class WithValues extends TypeSafeDiagnosingMatcher<ContentProviderO
     @Override
     protected boolean matchesSafely(ContentProviderOperation.Builder builder, Description mismatchDescription)
     {
-        ContentValues values = new NullSafe<>(new Field<ContentValues>(builder, "mValues").value()).value(new ContentValues());
+        ContentValues values = new Backed<>(new NullSafe<>(new Field<ContentValues>(builder, "mValues").value()), new ContentValues()).value();
 
         if (!mValueMatcher.matches(values))
         {

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/Mocked.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/Mocked.java
@@ -20,11 +20,10 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.iterables.ArrayIterable;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
 
 
 /**
@@ -42,7 +41,7 @@ public final class Mocked implements Predicate
     public Mocked(CharSequence selection, String... arguments)
     {
         mSelection = selection;
-        mArguments = new ArrayIterable<>(arguments);
+        mArguments = new Seq<>(arguments);
     }
 
 
@@ -58,14 +57,7 @@ public final class Mocked implements Predicate
     @Override
     public Iterable<Argument> arguments(@NonNull TransactionContext transactionContext)
     {
-        return new Mapped<>(mArguments, new Function<String, Argument>()
-        {
-            @Override
-            public Argument apply(String argument)
-            {
-                return new ValueArgument(argument);
-            }
-        });
+        return new Mapped<>(ValueArgument::new, mArguments);
     }
 
 

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateArgumentMatcher.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateArgumentMatcher.java
@@ -18,10 +18,11 @@ package org.dmfs.android.contentpal.testing.predicates;
 
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Present;
+import org.dmfs.jems.optional.elementary.Present;
 import org.mockito.ArgumentMatcher;
 import org.mockito.hamcrest.MockitoHamcrest;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -34,7 +35,7 @@ public final class PredicateArgumentMatcher
 
     public static Predicate predicateWithSelection(CharSequence expectedSelection)
     {
-        return MockitoHamcrest.argThat(new PredicateMatcher.Selection(Absent.<TransactionContext>absent(), expectedSelection));
+        return MockitoHamcrest.argThat(new PredicateMatcher.Selection(absent(), expectedSelection));
     }
 
 

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcher.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcher.java
@@ -18,11 +18,11 @@ package org.dmfs.android.contentpal.testing.predicates;
 
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.Present;
+import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
+import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
+import org.dmfs.jems.single.combined.Backed;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Factory;
 import org.hamcrest.FeatureMatcher;
@@ -30,9 +30,9 @@ import org.hamcrest.Matcher;
 
 import java.util.Arrays;
 
-import static org.dmfs.jems.hamcrest.matchers.AbsentMatcher.isAbsent;
 import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
 import static org.hamcrest.object.HasToString.hasToString;
 
@@ -56,7 +56,7 @@ public final class PredicateMatcher
     @Factory
     public static Matcher<Predicate> selection(CharSequence selection)
     {
-        return new Selection(Absent.<TransactionContext>absent(), selection);
+        return new Selection(absent(), selection);
     }
 
 
@@ -70,7 +70,7 @@ public final class PredicateMatcher
     @Factory
     public static Matcher<Predicate> emptyArguments()
     {
-        return new EmptyArgument(Absent.<TransactionContext>absent());
+        return new EmptyArgument(absent());
     }
 
 
@@ -84,7 +84,7 @@ public final class PredicateMatcher
     @Factory
     public static Matcher<Predicate> argumentValues(String... values)
     {
-        return new ArgumentValues(Absent.<TransactionContext>absent(), values);
+        return new ArgumentValues(absent(), values);
     }
 
 
@@ -99,7 +99,7 @@ public final class PredicateMatcher
     @SafeVarargs
     public static Matcher<Predicate> backReferences(Matcher<Optional<Integer>>... backReferences)
     {
-        return new ArgumentBackReferences(Absent.<TransactionContext>absent(), backReferences);
+        return new ArgumentBackReferences(absent(), backReferences);
     }
 
 
@@ -115,8 +115,8 @@ public final class PredicateMatcher
     public static Matcher<Predicate> absentBackReferences(int noOfPredicateArguments)
     {
         Matcher[] matchers = new Matcher[noOfPredicateArguments];
-        Arrays.fill(matchers, isAbsent());
-        return new ArgumentBackReferences(Absent.<TransactionContext>absent(), matchers);
+        Arrays.fill(matchers, AbsentMatcher.absent());
+        return new ArgumentBackReferences(absent(), matchers);
     }
 
 
@@ -124,7 +124,7 @@ public final class PredicateMatcher
     public static Matcher<Predicate> absentBackReferences(TransactionContext tc, int noOfPredicateArguments)
     {
         Matcher[] matchers = new Matcher[noOfPredicateArguments];
-        Arrays.fill(matchers, isAbsent());
+        Arrays.fill(matchers, AbsentMatcher.absent());
         return new ArgumentBackReferences(new Present<>(tc), matchers);
     }
 
@@ -150,7 +150,7 @@ public final class PredicateMatcher
         @Override
         protected CharSequence featureValueOf(Predicate actual)
         {
-            return actual.selection(mTc.value(dummy(TransactionContext.class)));
+            return actual.selection(new Backed<>(mTc, dummy(TransactionContext.class)).value());
         }
     }
 
@@ -171,14 +171,7 @@ public final class PredicateMatcher
         @Override
         protected Iterable<String> featureValueOf(Predicate predicate)
         {
-            return new Mapped<>(predicate.arguments(mTc.value(dummy(TransactionContext.class))), new Function<Predicate.Argument, String>()
-            {
-                @Override
-                public String apply(Predicate.Argument argument)
-                {
-                    return argument.value();
-                }
-            });
+            return new Mapped<>(Predicate.Argument::value, predicate.arguments(new Backed<>(mTc, dummy(TransactionContext.class)).value()));
         }
     }
 
@@ -199,7 +192,7 @@ public final class PredicateMatcher
         @Override
         protected Iterable<Predicate.Argument> featureValueOf(Predicate predicate)
         {
-            return predicate.arguments(mTc.value(dummy(TransactionContext.class)));
+            return predicate.arguments(new Backed<>(mTc, dummy(TransactionContext.class)).value());
         }
     }
 
@@ -221,14 +214,7 @@ public final class PredicateMatcher
         @Override
         protected Iterable<Optional<Integer>> featureValueOf(Predicate predicate)
         {
-            return new Mapped<>(predicate.arguments(mTc.value(dummy(TransactionContext.class))), new Function<Predicate.Argument, Optional<Integer>>()
-            {
-                @Override
-                public Optional<Integer> apply(Predicate.Argument argument)
-                {
-                    return argument.backReference();
-                }
-            });
+            return new Mapped<>(Predicate.Argument::backReference, predicate.arguments(new Backed<>(mTc, dummy(TransactionContext.class)).value()));
         }
     }
 

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/rowset/TestRowSet.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/rowset/TestRowSet.java
@@ -22,7 +22,7 @@ import org.dmfs.android.contentpal.ClosableIterator;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.testing.tools.FakeClosable;
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.elementary.Seq;
 
 
 /**
@@ -44,7 +44,7 @@ public final class TestRowSet<T> implements RowSet<T>
     @SafeVarargs
     public TestRowSet(RowSnapshot<T>... rowSnapshots)
     {
-        this(new ArrayIterable<>(rowSnapshots));
+        this(new Seq<>(rowSnapshots));
     }
 
 

--- a/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcherTest.java
+++ b/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcherTest.java
@@ -18,11 +18,10 @@ package org.dmfs.android.contentpal.testing.predicates;
 
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Present;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
+import org.dmfs.jems.optional.elementary.Present;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.argumentValues;
@@ -30,9 +29,11 @@ import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.ba
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.emptyArguments;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.predicateWith;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.selection;
-import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -76,23 +77,23 @@ public final class PredicateMatcherTest
         // Single matching
         Predicate.Argument argumentA = when(mock(Predicate.Argument.class).value()).thenReturn("a").getMock();
         assertTrue(argumentValues("a").matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new ArrayIterable<>(argumentA)).getMock()));
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new Seq<>(argumentA)).getMock()));
         // Single non-matching
         assertFalse(argumentValues("b").matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new ArrayIterable<>(argumentA)).getMock()));
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new Seq<>(argumentA)).getMock()));
 
         // Multiple
         Predicate.Argument aB = when(mock(Predicate.Argument.class).value()).thenReturn("b").getMock();
         Predicate.Argument aC = when(mock(Predicate.Argument.class).value()).thenReturn("c").getMock();
         Predicate.Argument aD = when(mock(Predicate.Argument.class).value()).thenReturn("d").getMock();
         assertTrue(argumentValues("b", "c", "d").matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new ArrayIterable<>(aB, aC, aD)).getMock()));
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new Seq<>(aB, aC, aD)).getMock()));
 
         // Single with TC
         TransactionContext dummyTc = dummy(TransactionContext.class);
         Predicate.Argument argumentE = when(mock(Predicate.Argument.class).value()).thenReturn("e").getMock();
         assertTrue(argumentValues(dummyTc, "e").matches(
-                when(mock(Predicate.class).arguments(dummyTc)).thenReturn(new ArrayIterable<>(argumentE)).getMock()));
+                when(mock(Predicate.class).arguments(dummyTc)).thenReturn(new Seq<>(argumentE)).getMock()));
     }
 
 
@@ -101,24 +102,24 @@ public final class PredicateMatcherTest
     {
         // Single matching
         Predicate.Argument argumentA = when(mock(Predicate.Argument.class).backReference()).thenReturn(new Present<>(1)).getMock();
-        assertTrue(backReferences(isPresent(1)).matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new ArrayIterable<>(argumentA)).getMock()));
+        assertTrue(backReferences(is(present(1))).matches(
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new Seq<>(argumentA)).getMock()));
         // Single non-matching
-        assertFalse(backReferences(isPresent(2)).matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new ArrayIterable<>(argumentA)).getMock()));
+        assertFalse(backReferences(is(present(2))).matches(
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new Seq<>(argumentA)).getMock()));
 
         // Multiple
         Predicate.Argument aB = when(mock(Predicate.Argument.class).backReference()).thenReturn(new Present<>(1)).getMock();
-        Predicate.Argument aC = when(mock(Predicate.Argument.class).backReference()).thenReturn(Absent.<Integer>absent()).getMock();
+        Predicate.Argument aC = when(mock(Predicate.Argument.class).backReference()).thenReturn(absent()).getMock();
         Predicate.Argument aD = when(mock(Predicate.Argument.class).backReference()).thenReturn(new Present<>(3)).getMock();
-        assertTrue(backReferences(isPresent(1), AbsentMatcher.<Integer>isAbsent(), isPresent(3)).matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new ArrayIterable<>(aB, aC, aD)).getMock()));
+        assertTrue(backReferences(is(present(1)), is(AbsentMatcher.absent()), is(present(3))).matches(
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new Seq<>(aB, aC, aD)).getMock()));
 
         // Single with TC
         TransactionContext dummyTc = dummy(TransactionContext.class);
         Predicate.Argument argumentE = when(mock(Predicate.Argument.class).backReference()).thenReturn(new Present<>(1)).getMock();
-        assertTrue(backReferences(dummyTc, isPresent(1)).matches(
-                when(mock(Predicate.class).arguments(dummyTc)).thenReturn(new ArrayIterable<>(argumentE)).getMock()));
+        assertTrue(backReferences(dummyTc, is(present(1))).matches(
+                when(mock(Predicate.class).arguments(dummyTc)).thenReturn(new Seq<>(argumentE)).getMock()));
     }
 
 
@@ -126,15 +127,15 @@ public final class PredicateMatcherTest
     public void testEmptyArguments()
     {
         assertTrue(emptyArguments().matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(EmptyIterable.<Predicate.Argument>instance()).getMock()));
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(EmptyIterable.instance()).getMock()));
 
         assertFalse(emptyArguments().matches(
-                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new ArrayIterable<>(dummy(Predicate.Argument.class)))
+                when(mock(Predicate.class).arguments(any(TransactionContext.class))).thenReturn(new Seq<>(dummy(Predicate.Argument.class)))
                         .getMock()));
 
         TransactionContext dummyTc = dummy(TransactionContext.class);
         assertTrue(emptyArguments(dummyTc).matches(
-                when(mock(Predicate.class).arguments(dummyTc)).thenReturn(EmptyIterable.<Predicate.Argument>instance()).getMock()));
+                when(mock(Predicate.class).arguments(dummyTc)).thenReturn(EmptyIterable.instance()).getMock()));
 
     }
 
@@ -147,10 +148,9 @@ public final class PredicateMatcherTest
 
         doReturn("sel").when(predicateMock).selection(any(TransactionContext.class));
         doReturn("arg").when(argumentMock).value();
-        doReturn(new ArrayIterable<>(argumentMock)).when(predicateMock).arguments(any(TransactionContext.class));
+        doReturn(new Seq<>(argumentMock)).when(predicateMock).arguments(any(TransactionContext.class));
 
-        assertTrue(predicateWith(selection("sel"), argumentValues("arg"))
-                .matches(predicateMock));
+        assertTrue(predicateWith(selection("sel"), argumentValues("arg")).matches(predicateMock));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/batches/MappedRowSetBatch.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/batches/MappedRowSetBatch.java
@@ -22,8 +22,8 @@ import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.iterables.decorators.DelegatingIterable;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
+import org.dmfs.jems.function.Function;
+import org.dmfs.jems.iterable.decorators.Mapped;
 
 
 /**
@@ -72,7 +72,7 @@ public final class MappedRowSetBatch<T> extends DelegatingIterable<Operation<?>>
      */
     public MappedRowSetBatch(@NonNull RowSet<T> rowSet, @NonNull Function<RowSnapshot<T>, Operation<?>> function)
     {
-        super(new Mapped<>(rowSet, function));
+        super(new Mapped<>(function, rowSet));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/batches/MultiInsertBatch.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/batches/MultiInsertBatch.java
@@ -23,11 +23,10 @@ import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.operations.Populated;
 import org.dmfs.iterables.decorators.DelegatingIterable;
-import org.dmfs.iterables.decorators.Mapped;
+import org.dmfs.iterables.elementary.PresentValues;
 import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.iterators.Function;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.iterable.PresentValues;
+import org.dmfs.jems.iterable.decorators.Mapped;
+import org.dmfs.jems.optional.Optional;
 
 
 /**
@@ -95,14 +94,7 @@ public final class MultiInsertBatch<T> extends DelegatingIterable<Operation<?>>
      */
     public MultiInsertBatch(@NonNull final InsertOperation<T> insertOperation, @NonNull Iterable<RowData<T>> data)
     {
-        super(new Mapped<>(data, new Function<RowData<T>, Operation<?>>()
-        {
-            @Override
-            public Operation<?> apply(RowData<T> argument)
-            {
-                return new Populated<>(argument, insertOperation);
-            }
-        }));
+        super(new Mapped<>(argument -> new Populated<>(argument, insertOperation), data));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/AccountScoped.java
@@ -23,7 +23,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Assert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Assert.java
@@ -24,8 +24,8 @@ import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkAssert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkAssert.java
@@ -28,8 +28,8 @@ import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.predicates.AnyOf;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkDelete.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkDelete.java
@@ -26,8 +26,8 @@ import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.predicates.AnyOf;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkUpdate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkUpdate.java
@@ -27,8 +27,9 @@ import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.predicates.AnyOf;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -61,7 +62,7 @@ public final class BulkUpdate<T> implements Operation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Counted.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Counted.java
@@ -23,7 +23,7 @@ import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/DelegatingInsertOperation.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/DelegatingInsertOperation.java
@@ -22,7 +22,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/DelegatingOperation.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/DelegatingOperation.java
@@ -22,7 +22,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Delete.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Delete.java
@@ -23,8 +23,9 @@ import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -53,7 +54,7 @@ public final class Delete<T> implements Operation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Insert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Insert.java
@@ -26,8 +26,9 @@ import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -70,7 +71,7 @@ public final class Insert<T> implements InsertOperation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Populated.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Populated.java
@@ -23,7 +23,7 @@ import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Put.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Put.java
@@ -25,8 +25,8 @@ import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.EmptyRowData;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.Present;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
 
 
 /**
@@ -42,7 +42,7 @@ public final class Put<T> implements Operation<T>
 
     public Put(@NonNull RowSnapshot<T> rowSnapshot)
     {
-        this(rowSnapshot, EmptyRowData.<T>instance());
+        this(rowSnapshot, EmptyRowData.instance());
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Yieldable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/Yieldable.java
@@ -22,7 +22,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawAssert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawAssert.java
@@ -25,8 +25,9 @@ import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.Assert;
 import org.dmfs.android.contentpal.operations.BulkAssert;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -52,7 +53,7 @@ public final class RawAssert<T> implements Operation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawDelete.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawDelete.java
@@ -24,8 +24,9 @@ import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.BulkDelete;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -51,7 +52,7 @@ public final class RawDelete<T> implements Operation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawInsert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawInsert.java
@@ -25,8 +25,9 @@ import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.Insert;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.optional.Absent.absent;
 
 
 /**
@@ -51,7 +52,7 @@ public class RawInsert<T> implements InsertOperation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawUpdate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/internal/RawUpdate.java
@@ -24,8 +24,9 @@ import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.operations.BulkUpdate;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -51,7 +52,7 @@ public final class RawUpdate<T> implements Operation<T>
     @Override
     public Optional<SoftRowReference<T>> reference()
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/BinaryPredicate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/BinaryPredicate.java
@@ -20,10 +20,9 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.iterables.ArrayIterable;
-import org.dmfs.iterables.decorators.Flattened;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.composite.Joined;
+import org.dmfs.jems.iterable.decorators.Mapped;
 
 
 /**
@@ -82,16 +81,9 @@ public final class BinaryPredicate implements Predicate
     @Override
     public Iterable<Argument> arguments(@NonNull final TransactionContext transactionContext)
     {
-        return new Flattened<>(
+        return new Joined<>(
                 new Mapped<>(
-                        new ArrayIterable<>(mPredicates),
-                        new Function<Predicate, Iterable<Argument>>()
-                        {
-                            @Override
-                            public Iterable<Argument> apply(Predicate predicate)
-                            {
-                                return predicate.arguments(transactionContext);
-                            }
-                        }));
+                        predicate -> predicate.arguments(transactionContext),
+                        new Seq<>(mPredicates)));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/In.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/In.java
@@ -21,9 +21,8 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.predicates.arguments.ValueArgument;
-import org.dmfs.iterables.ArrayIterable;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.decorators.Mapped;
 
 
 /**
@@ -71,15 +70,6 @@ public final class In implements Predicate
     @Override
     public Iterable<Argument> arguments(@NonNull TransactionContext transactionContext)
     {
-        return new Mapped<>(
-                new ArrayIterable<>(mArguments),
-                new Function<Object, Argument>()
-                {
-                    @Override
-                    public Argument apply(Object argument)
-                    {
-                        return new ValueArgument(argument);
-                    }
-                });
+        return new Mapped<>(ValueArgument::new, new Seq<>(mArguments));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/arguments/BackReferenceArgument.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/arguments/BackReferenceArgument.java
@@ -20,8 +20,8 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.Transaction;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.Present;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/arguments/ValueArgument.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/arguments/ValueArgument.java
@@ -19,8 +19,9 @@ package org.dmfs.android.contentpal.predicates.arguments;
 import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.Predicate;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -51,6 +52,6 @@ public final class ValueArgument implements Predicate.Argument
     @Override
     public Optional<Integer> backReference()
     {
-        return Absent.absent();
+        return absent();
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowdata/Composite.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowdata/Composite.java
@@ -21,9 +21,9 @@ import android.support.annotation.NonNull;
 
 import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.iterables.ArrayIterable;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.iterable.PresentValues;
+import org.dmfs.iterables.elementary.PresentValues;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.optional.Optional;
 
 
 /**
@@ -39,14 +39,14 @@ public final class Composite<T> implements RowData<T>
     @SafeVarargs
     public Composite(Optional<RowData<T>>... optionalDelegates)
     {
-        this(new PresentValues<>(new ArrayIterable<>(optionalDelegates)));
+        this(new PresentValues<>(new Seq<>(optionalDelegates)));
     }
 
 
     @SafeVarargs
     public Composite(RowData<T>... delegates)
     {
-        this(new ArrayIterable<>(delegates));
+        this(new Seq<>(delegates));
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowdatasnapshots/EmptyRowDataSnapshot.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowdatasnapshots/EmptyRowDataSnapshot.java
@@ -21,10 +21,11 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.iterators.EmptyIterator;
 import org.dmfs.jems.function.Function;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 import java.util.Iterator;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -41,7 +42,7 @@ public final class EmptyRowDataSnapshot<Contract> implements RowDataSnapshot<Con
     @Override
     public <ValueType> Optional<ValueType> data(@NonNull String key, @NonNull Function<String, ValueType> mapFunction)
     {
-        return Absent.absent();
+        return absent();
     }
 
 
@@ -49,7 +50,7 @@ public final class EmptyRowDataSnapshot<Contract> implements RowDataSnapshot<Con
     @Override
     public Optional<byte[]> byteData(@NonNull String key)
     {
-        return Absent.absent();
+        return absent();
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowdatasnapshots/MapRowDataSnapshot.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowdatasnapshots/MapRowDataSnapshot.java
@@ -21,9 +21,9 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.RowDataSnapshot;
 import org.dmfs.iterators.decorators.Serialized;
 import org.dmfs.jems.function.Function;
+import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.decorators.Mapped;
-import org.dmfs.optional.NullSafe;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.elementary.NullSafe;
 
 import java.util.HashMap;
 import java.util.Iterator;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
@@ -33,12 +33,13 @@ import org.dmfs.android.contentpal.tools.ClosableEmptyIterator;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
 import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.dmfs.iterators.AbstractBaseIterator;
-import org.dmfs.optional.Absent;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -67,7 +68,7 @@ public final class QueryRowSet<T> implements RowSet<T>
     {
         try
         {
-            Cursor cursor = mView.rows(EmptyUriParams.INSTANCE, mProjection, mPredicate,  /* no specific sorting */Absent.<String>absent());
+            Cursor cursor = mView.rows(EmptyUriParams.INSTANCE, mProjection, mPredicate,  /* no specific sorting */absent());
             if (!cursor.moveToFirst())
             {
                 cursor.close();

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
@@ -34,7 +34,7 @@ import org.dmfs.android.contentpal.operations.internal.RawDelete;
 import org.dmfs.android.contentpal.operations.internal.RawInsert;
 import org.dmfs.android.contentpal.operations.internal.RawUpdate;
 import org.dmfs.android.contentpal.views.BaseView;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tools/RowCount.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tools/RowCount.java
@@ -26,7 +26,8 @@ import org.dmfs.android.contentpal.predicates.AnyOf;
 import org.dmfs.android.contentpal.projections.SingleColProjection;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
 import org.dmfs.jems.single.Single;
-import org.dmfs.optional.Absent;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 
 
 /**
@@ -59,7 +60,7 @@ public final class RowCount<T> implements Single<Integer>
         Cursor cursor = null;
         try
         {
-            cursor = mView.rows(EmptyUriParams.INSTANCE, new SingleColProjection(BaseColumns._ID), mPredicate, Absent.<String>absent());
+            cursor = mView.rows(EmptyUriParams.INSTANCE, new SingleColProjection(BaseColumns._ID), mPredicate, absent());
             return cursor.getCount();
         }
         catch (RemoteException e)

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/BaseTransaction.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/transactions/BaseTransaction.java
@@ -35,7 +35,7 @@ import org.dmfs.android.contentpal.references.RowUriReference;
 import org.dmfs.android.contentpal.tools.OperationSize;
 import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.dmfs.android.contentpal.transactions.contexts.Quick;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
@@ -29,7 +29,7 @@ import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.predicates.AccountEq;
 import org.dmfs.android.contentpal.predicates.AllOf;
 import org.dmfs.android.contentpal.tools.uriparams.AccountScopedParams;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/BaseView.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/BaseView.java
@@ -30,7 +30,8 @@ import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.tables.BaseTable;
 import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.single.combined.Backed;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -71,7 +72,7 @@ public final class BaseView<T> implements View<T>
                 projectionArray,
                 predicate.selection(EmptyTransactionContext.INSTANCE).toString(),
                 args.toArray(new String[args.size()]),
-                sorting.value(null /* fallback: null */));
+                new Backed<>(sorting, (String) null).value());
         return cursor == null ? new MatrixCursor(projectionArray) : cursor;
     }
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/DelegatingView.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/DelegatingView.java
@@ -25,7 +25,7 @@ import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/Sorted.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/Sorted.java
@@ -26,8 +26,9 @@ import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.Present;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.adapters.SinglePresent;
+import org.dmfs.jems.single.combined.Backed;
 
 
 /**
@@ -55,7 +56,7 @@ public final class Sorted<T> implements View<T>
     @Override
     public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(uriParams, projection, predicate, new Present<>(sorting.value(mSorting)));
+        return mDelegate.rows(uriParams, projection, predicate, new SinglePresent<>(new Backed<>(sorting, mSorting)));
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
@@ -26,7 +26,7 @@ import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.tools.uriparams.SyncParams;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 
 /**

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MappedRowSetBatchTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MappedRowSetBatchTest.java
@@ -21,10 +21,9 @@ import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.testing.rowset.TestRowSet;
 import org.dmfs.android.contentpal.testing.table.Contract;
-import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.iterables.decorators.DelegatingIterable;
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterators.Function;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.decorators.Mapped;
 import org.dmfs.jems.mocks.MockFunction;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
@@ -47,9 +46,10 @@ public final class MappedRowSetBatchTest
     public void test()
     {
         RowSet<Contract> rowSet = new TestRowSet<Contract>(dummy(RowSnapshot.class), dummy(RowSnapshot.class), dummy(RowSnapshot.class));
-        Iterable<Operation<?>> dummyOperations = new ArrayIterable<Operation<?>>(dummy(Operation.class), dummy(Operation.class), dummy(Operation.class));
+        Iterable<Operation<?>> dummyOperations = new Seq<Operation<?>>(dummy(Operation.class), dummy(Operation.class), dummy(Operation.class));
 
-        assertThat(new MappedRowSetBatch<>(rowSet, new MockFunction<>(new InstanceMatching<>(rowSet), dummyOperations)),
+        // TODO: method reference when we have a MockFunction implementing the new Function interface
+        assertThat(new MappedRowSetBatch<>(rowSet, new MockFunction<>(new InstanceMatching<>(rowSet), dummyOperations)::apply),
                 iteratesTo(new InstanceMatching<>(dummyOperations)));
     }
 
@@ -59,14 +59,7 @@ public final class MappedRowSetBatchTest
     {
         InstanceMatching(Iterable<T> delegate)
         {
-            super(new Mapped<>(delegate, new Function<T, Matcher<T>>()
-            {
-                @Override
-                public Matcher<T> apply(T argument)
-                {
-                    return CoreMatchers.sameInstance(argument);
-                }
-            }));
+            super(new Mapped<>(CoreMatchers::sameInstance, delegate));
         }
     }
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MultiInsertBatchTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MultiInsertBatchTest.java
@@ -25,7 +25,7 @@ import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
 import org.dmfs.android.contentpal.rowdata.Composite;
 import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.optional.Absent;
+import org.dmfs.jems.optional.elementary.Absent;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,8 +71,8 @@ public class MultiInsertBatchTest
         });
 
         assertThat(new MultiInsertBatch<>(mockOp, new Seq<RowData<Object>>()), emptyIterable());
-        assertThat(new MultiInsertBatch<>(mockOp, Absent.<RowData<Object>>absent()), emptyIterable());
-        assertThat(new MultiInsertBatch<>(mockOp, Absent.<RowData<Object>>absent(), Absent.<RowData<Object>>absent()), emptyIterable());
+        assertThat(new MultiInsertBatch<>(mockOp, Absent.absent()), emptyIterable());
+        assertThat(new MultiInsertBatch<>(mockOp, Absent.absent(), Absent.absent()), emptyIterable());
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AccountScopedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AccountScopedTest.java
@@ -22,7 +22,7 @@ import android.net.Uri;
 import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.operations.internal.RawInsert;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/AssertTest.java
@@ -24,7 +24,6 @@ import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -37,6 +36,7 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithVa
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.core.IsSame.sameInstance;
@@ -58,8 +58,7 @@ public final class AssertTest
     @Test
     public void testReference() throws Exception
     {
-        assertThat(new Assert<Object>(dummy(RowSnapshot.class), dummy(RowData.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new Assert<Object>(dummy(RowSnapshot.class), dummy(RowData.class)).reference(), absent());
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
@@ -22,12 +22,10 @@ import android.net.Uri;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.RowData;
-import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -42,6 +40,7 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYi
 import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateArgumentMatcher.predicateWithSelection;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.core.IsSame.sameInstance;
@@ -64,17 +63,13 @@ public final class BulkAssertTest
     @Test
     public void testReference()
     {
-        assertThat(new BulkAssert<Object>(dummy(Table.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new BulkAssert<Object>(dummy(Table.class)).reference(), absent());
 
-        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(Predicate.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(Predicate.class)).reference(), absent());
 
-        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(RowData.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(RowData.class)).reference(), absent());
 
-        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(RowData.class), dummy(Predicate.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new BulkAssert<Object>(dummy(Table.class), dummy(RowData.class), dummy(Predicate.class)).reference(), absent());
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
@@ -21,11 +21,9 @@ import android.net.Uri;
 
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.Predicate;
-import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -38,6 +36,7 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithVa
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateArgumentMatcher.predicateWithSelection;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.core.IsSame.sameInstance;
@@ -61,11 +60,9 @@ public final class BulkDeleteTest
     @Test
     public void testReference()
     {
-        assertThat(new BulkDelete<Object>(dummy(Table.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new BulkDelete<Object>(dummy(Table.class)).reference(), absent());
 
-        assertThat(new BulkDelete<Object>(dummy(Table.class), dummy(Predicate.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new BulkDelete<Object>(dummy(Table.class), dummy(Predicate.class)).reference(), absent());
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
@@ -22,12 +22,10 @@ import android.net.Uri;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.RowData;
-import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -41,8 +39,10 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYi
 import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateArgumentMatcher.predicateWithSelection;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -64,10 +64,10 @@ public final class BulkUpdateTest
     public void testReference()
     {
         assertThat(new BulkUpdate<Object>(dummy(Table.class), dummy(RowData.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+                is(absent()));
 
         assertThat(new BulkUpdate<Object>(dummy(Table.class), dummy(RowData.class), dummy(Predicate.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+                is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/CountedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/CountedTest.java
@@ -21,7 +21,7 @@ import android.net.Uri;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.operations.internal.RawUpdate;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DelegatingInsertOperationTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DelegatingInsertOperationTest.java
@@ -22,7 +22,7 @@ import android.support.annotation.NonNull;
 import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 import org.junit.Test;
 
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DelegatingOperationTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DelegatingOperationTest.java
@@ -21,7 +21,7 @@ import android.content.ContentProviderOperation;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 import org.junit.Test;
 
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/DeleteTest.java
@@ -22,7 +22,6 @@ import android.net.Uri;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.TransactionContext;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -34,8 +33,10 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithEx
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,7 +55,7 @@ public class DeleteTest
     {
         RowSnapshot<Object> dummyRowSnapshot = dummy(RowSnapshot.class);
 
-        assertThat(new Delete<>(dummyRowSnapshot).reference(), AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new Delete<>(dummyRowSnapshot).reference(), is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/InsertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/InsertTest.java
@@ -19,12 +19,10 @@ package org.dmfs.android.contentpal.operations;
 import android.net.Uri;
 
 import org.dmfs.android.contentpal.RowData;
-import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.operations.internal.RawInsert;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -38,8 +36,10 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithVa
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -57,11 +57,11 @@ public class InsertTest
     {
         Table<Object> mockTable = failingMock(Table.class);
 
-        assertThat(new Insert<Object>(mockTable).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new Insert<>(mockTable).reference(),
+                is(absent()));
 
         assertThat(new Insert<Object>(mockTable, dummy(RowData.class)).reference(),
-                AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+                is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PopulatedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PopulatedTest.java
@@ -22,7 +22,7 @@ import org.dmfs.android.contentpal.InsertOperation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.operations.internal.RawInsert;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PutTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/PutTest.java
@@ -36,10 +36,11 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithVa
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.contentvalues.Containing.containing;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
-import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -62,7 +63,7 @@ public class PutTest
         doReturn(dummyReference).when(mockRowSnapshot).reference();
         doReturn(ContentProviderOperation.newUpdate(Uri.EMPTY)).when(dummyReference).putOperationBuilder(any(TransactionContext.class));
 
-        assertThat(new Put<>(mockRowSnapshot).reference(), isPresent(sameInstance(dummyReference)));
+        assertThat(new Put<>(mockRowSnapshot).reference(), is(present(sameInstance(dummyReference))));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/ReferringTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/ReferringTest.java
@@ -23,7 +23,7 @@ import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.operations.internal.RawInsert;
 import org.dmfs.android.contentpal.references.RowUriReference;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/YieldableTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/YieldableTest.java
@@ -21,7 +21,7 @@ import android.net.Uri;
 import org.dmfs.android.contentpal.Operation;
 import org.dmfs.android.contentpal.SoftRowReference;
 import org.dmfs.android.contentpal.operations.internal.RawInsert;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawAssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawAssertTest.java
@@ -18,8 +18,6 @@ package org.dmfs.android.contentpal.operations.internal;
 
 import android.net.Uri;
 
-import org.dmfs.android.contentpal.SoftRowReference;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -31,7 +29,9 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithEx
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -46,7 +46,7 @@ public class RawAssertTest
     @Test
     public void testReference() throws Exception
     {
-        assertThat(new RawAssert<>(dummy(Uri.class)).reference(), AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new RawAssert<>(dummy(Uri.class)).reference(), is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawDeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawDeleteTest.java
@@ -18,8 +18,6 @@ package org.dmfs.android.contentpal.operations.internal;
 
 import android.net.Uri;
 
-import org.dmfs.android.contentpal.SoftRowReference;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -31,7 +29,9 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithEx
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -46,7 +46,7 @@ public class RawDeleteTest
     @Test
     public void testReference() throws Exception
     {
-        assertThat(new RawDelete<>(dummy(Uri.class)).reference(), AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new RawDelete<>(dummy(Uri.class)).reference(), is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawInsertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawInsertTest.java
@@ -18,8 +18,6 @@ package org.dmfs.android.contentpal.operations.internal;
 
 import android.net.Uri;
 
-import org.dmfs.android.contentpal.SoftRowReference;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -31,7 +29,9 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithEx
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -46,7 +46,7 @@ public class RawInsertTest
     @Test
     public void testReference() throws Exception
     {
-        assertThat(new RawInsert<>(dummy(Uri.class)).reference(), AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new RawInsert<>(dummy(Uri.class)).reference(), is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawUpdateTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/internal/RawUpdateTest.java
@@ -18,8 +18,6 @@ package org.dmfs.android.contentpal.operations.internal;
 
 import android.net.Uri;
 
-import org.dmfs.android.contentpal.SoftRowReference;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -31,7 +29,9 @@ import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithEx
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithValues.withoutValues;
 import static org.dmfs.android.contentpal.testing.contentoperationbuilder.WithYieldAllowed.withYieldNotAllowed;
 import static org.dmfs.android.contentpal.testing.operations.OperationMatcher.builds;
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -46,7 +46,7 @@ public class RawUpdateTest
     @Test
     public void testReference() throws Exception
     {
-        assertThat(new RawUpdate<>(dummy(Uri.class)).reference(), AbsentMatcher.<SoftRowReference<Object>>isAbsent());
+        assertThat(new RawUpdate<>(dummy(Uri.class)).reference(), is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/ReferringToTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/ReferringToTest.java
@@ -28,9 +28,10 @@ import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.ar
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.backReferences;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.predicateWith;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.selection;
-import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
@@ -57,7 +58,7 @@ public class ReferringToTest
                 predicateWith(
                         selection(mockTc, "x = ?"),
                         argumentValues(mockTc, "-1"),
-                        backReferences(mockTc, isPresent(10))
+                        backReferences(mockTc, is(present(10)))
                 ));
     }
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/arguments/BackReferenceArgumentTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/arguments/BackReferenceArgumentTest.java
@@ -19,7 +19,7 @@ package org.dmfs.android.contentpal.predicates.arguments;
 import org.dmfs.android.contentpal.Predicate;
 import org.junit.Test;
 
-import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -37,6 +37,6 @@ public final class BackReferenceArgumentTest
     {
         Predicate.Argument underTest = new BackReferenceArgument(4);
         assertThat(underTest.value(), is("-1"));
-        assertThat(underTest.backReference(), isPresent(4));
+        assertThat(underTest.backReference(), is(present(4)));
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/arguments/ValueArgumentTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/arguments/ValueArgumentTest.java
@@ -17,9 +17,9 @@
 package org.dmfs.android.contentpal.predicates.arguments;
 
 import org.dmfs.android.contentpal.Predicate;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -42,7 +42,7 @@ public final class ValueArgumentTest
 
         Predicate.Argument underTest = new ValueArgument(mockValue);
         assertThat(underTest.value(), is("val"));
-        assertThat(underTest.backReference(), AbsentMatcher.<Integer>isAbsent());
+        assertThat(underTest.backReference(), is(absent()));
     }
 
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/references/BackReferenceTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/references/BackReferenceTest.java
@@ -37,9 +37,10 @@ import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.ar
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.backReferences;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.predicateWith;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.selection;
-import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
@@ -120,7 +121,7 @@ public class BackReferenceTest
                 predicateWith(
                         selection(mockTc, "testcol = ?"),
                         argumentValues(mockTc, "-1"),
-                        backReferences(mockTc, isPresent(123))
+                        backReferences(mockTc, is(present(123)))
                 ));
     }
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/rowdata/CompositeTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/rowdata/CompositeTest.java
@@ -17,11 +17,11 @@
 package org.dmfs.android.contentpal.rowdata;
 
 import org.dmfs.android.contentpal.RowData;
-import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Optional;
-import org.dmfs.optional.Present;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.elementary.Present;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -121,14 +121,14 @@ public class CompositeTest
     @Test
     public void testIterable() throws Exception
     {
-        assertThat(new Composite<Object>(
-                        new ArrayIterable<RowData<Object>>(
+        assertThat(new Composite<>(
+                        new Seq<RowData<Object>>(
                                 new CharSequenceRowData<>("key", "value"))),
                 builds(
                         withValuesOnly(
                                 containing("key", "value"))));
-        assertThat(new Composite<Object>(
-                        new ArrayIterable<RowData<Object>>(
+        assertThat(new Composite<>(
+                        new Seq<RowData<Object>>(
                                 new CharSequenceRowData<>("key", "value"),
                                 new CharSequenceRowData<>("key2", "value2"))),
                 builds(

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/rowdatasnapshots/EmptyRowDataSnapshotTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/rowdatasnapshots/EmptyRowDataSnapshotTest.java
@@ -16,11 +16,11 @@
 
 package org.dmfs.android.contentpal.rowdatasnapshots;
 
-import org.dmfs.jems.function.elementary.IdentityFunction;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 
@@ -32,14 +32,14 @@ public class EmptyRowDataSnapshotTest
     @Test
     public void testCharData() throws Exception
     {
-        assertThat(new EmptyRowDataSnapshot<>().data("key", new IdentityFunction<String>()), AbsentMatcher.<String>isAbsent());
+        assertThat(new EmptyRowDataSnapshot<>().data("key", x -> x), is(absent()));
     }
 
 
     @Test
     public void testByteData() throws Exception
     {
-        assertThat(new EmptyRowDataSnapshot<>().byteData("key"), AbsentMatcher.<byte[]>isAbsent());
+        assertThat(new EmptyRowDataSnapshot<>().byteData("key"), is(absent()));
     }
 
 

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/tools/RowCountTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/tools/RowCountTest.java
@@ -26,12 +26,12 @@ import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
 import org.dmfs.jems.mockito.answers.FailAnswer;
-import org.dmfs.optional.Absent;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.predicates.PredicateArgumentMatcher.predicateWithSelection;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -59,7 +59,7 @@ public final class RowCountTest
         Predicate dummyPredicate = dummy(Predicate.class);
         Cursor mockCursor = failingMock(Cursor.class);
 
-        doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(Absent.<String>absent()));
+        doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(absent()));
         doReturn(4).when(mockCursor).getCount();
         doNothing().when(mockCursor).close();
 
@@ -75,7 +75,7 @@ public final class RowCountTest
         Cursor mockCursor = failingMock(Cursor.class);
 
         doReturn(mockCursor).when(mockView)
-                .rows(same(EmptyUriParams.INSTANCE), any(Projection.class), predicateWithSelection("1"), same(Absent.<String>absent()));
+                .rows(same(EmptyUriParams.INSTANCE), any(Projection.class), predicateWithSelection("1"), same(absent()));
         doReturn(5).when(mockCursor).getCount();
         doNothing().when(mockCursor).close();
 
@@ -92,7 +92,7 @@ public final class RowCountTest
         Predicate dummyPredicate = dummy(Predicate.class);
 
         doThrow(new RemoteException("msg")).when(mockView)
-                .rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(Absent.<String>absent()));
+                .rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(absent()));
 
         new RowCount<>(mockView, dummyPredicate).value();
     }
@@ -105,7 +105,7 @@ public final class RowCountTest
         Predicate dummyPredicate = mock(Predicate.class, new FailAnswer());
         Cursor mockCursor = mock(Cursor.class, new FailAnswer());
 
-        doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(Absent.<String>absent()));
+        doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(absent()));
         doThrow(new RuntimeException("msg")).when(mockCursor).getCount();
         doNothing().when(mockCursor).close();
 


### PR DESCRIPTION
This commit replaces all deprecated jems classed with their new counterparts.
This also fixes a few other compiler warnings.