### PR TITLE
Let Synced set account uri params, implements #194

### DIFF
--- a/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
+++ b/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
@@ -128,8 +128,8 @@ public class DemoActivity extends AppCompatActivity
 
         mRawContacts = new Local(new RawContacts());
 
-        mCalendars = new org.dmfs.android.contentpal.tables.Synced<>(
-                new AccountScoped<>(new Account("Local", CalendarContract.ACCOUNT_TYPE_LOCAL), new Calendars()));
+        Account account = new Account("Local", CalendarContract.ACCOUNT_TYPE_LOCAL);
+        mCalendars = new org.dmfs.android.contentpal.tables.Synced<>(account, new AccountScoped<>(account, new Calendars()));
         mEvents = new Events();
     }
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/operations/LocalAccountScoped.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/operations/LocalAccountScoped.java
@@ -27,7 +27,8 @@ import org.dmfs.jems.optional.Optional;
 
 
 /**
- * A {@link InsertOperation} decorator which adds {@code account_type} and {@code account_name} values to the inserted {@link ContactsContract.RawContacts} row.
+ * A {@link InsertOperation} decorator which adds {@code account_type} and {@code account_name} values to the inserted {@link ContactsContract.RawContacts}
+ * row.
  *
  * @author Marten Gajda
  */

--- a/contentpal-testing/build.gradle
+++ b/contentpal-testing/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     implementation deps.junit
     implementation deps.hamcrest
     implementation deps.mockito
-    implementation deps.dmfs_jems_testing
+    implementation(deps.dmfs_jems_testing) {
+        // need to exlude this as long as it imports hamcrest-all which conflicts with hamcrest-library
+        exclude group: 'org.hamcrest'
+    }
     testImplementation deps.roboelectric
 }

--- a/contentpal/build.gradle
+++ b/contentpal/build.gradle
@@ -54,5 +54,4 @@ dependencies {
     testImplementation deps.mockito
     testImplementation deps.roboelectric
     testImplementation deps.dmfs_jems_testing
-
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
@@ -64,7 +64,7 @@ public final class AccountScoped<T> implements Table<T>
     @Override
     public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.updateOperation(new AccountScopedParams(mAccount, uriParams), accountScoped(predicate));
+        return mDelegate.updateOperation(uriParams, accountScoped(predicate));
     }
 
 
@@ -72,7 +72,7 @@ public final class AccountScoped<T> implements Table<T>
     @Override
     public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.deleteOperation(new AccountScopedParams(mAccount, uriParams), accountScoped(predicate));
+        return mDelegate.deleteOperation(uriParams, accountScoped(predicate));
     }
 
 
@@ -80,7 +80,7 @@ public final class AccountScoped<T> implements Table<T>
     @Override
     public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.assertOperation(new AccountScopedParams(mAccount, uriParams), accountScoped(predicate));
+        return mDelegate.assertOperation(uriParams, accountScoped(predicate));
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.tables;
 
+import android.accounts.Account;
 import android.content.ContentProviderClient;
 import android.support.annotation.NonNull;
 
@@ -25,6 +26,7 @@ import org.dmfs.android.contentpal.Predicate;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
+import org.dmfs.android.contentpal.tools.uriparams.AccountScopedParams;
 import org.dmfs.android.contentpal.tools.uriparams.SyncParams;
 
 
@@ -39,11 +41,13 @@ import org.dmfs.android.contentpal.tools.uriparams.SyncParams;
  */
 public final class Synced<T> implements Table<T>
 {
+    private final Account mAccount;
     private final Table<T> mDelegate;
 
 
-    public Synced(@NonNull Table<T> delegate)
+    public Synced(@NonNull Account account, @NonNull Table<T> delegate)
     {
+        mAccount = account;
         mDelegate = delegate;
     }
 
@@ -52,7 +56,7 @@ public final class Synced<T> implements Table<T>
     @Override
     public InsertOperation<T> insertOperation(@NonNull UriParams uriParams)
     {
-        return mDelegate.insertOperation(new SyncParams(uriParams));
+        return mDelegate.insertOperation(new AccountScopedParams(mAccount, new SyncParams(uriParams)));
     }
 
 
@@ -60,7 +64,7 @@ public final class Synced<T> implements Table<T>
     @Override
     public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.updateOperation(new SyncParams(uriParams), predicate);
+        return mDelegate.updateOperation(new AccountScopedParams(mAccount, new SyncParams(uriParams)), predicate);
     }
 
 
@@ -68,7 +72,7 @@ public final class Synced<T> implements Table<T>
     @Override
     public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.deleteOperation(new SyncParams(uriParams), predicate);
+        return mDelegate.deleteOperation(new AccountScopedParams(mAccount, new SyncParams(uriParams)), predicate);
     }
 
 
@@ -76,7 +80,7 @@ public final class Synced<T> implements Table<T>
     @Override
     public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
     {
-        return mDelegate.assertOperation(new SyncParams(uriParams), predicate);
+        return mDelegate.assertOperation(new AccountScopedParams(mAccount, new SyncParams(uriParams)), predicate);
     }
 
 
@@ -84,7 +88,7 @@ public final class Synced<T> implements Table<T>
     @Override
     public View<T> view(@NonNull ContentProviderClient client)
     {
-        return new org.dmfs.android.contentpal.views.Synced<>(mDelegate.view(client));
+        return new org.dmfs.android.contentpal.views.Synced<>(mAccount, mDelegate.view(client));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
@@ -28,12 +28,11 @@ import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
 import org.dmfs.android.contentpal.predicates.AccountEq;
 import org.dmfs.android.contentpal.predicates.AllOf;
-import org.dmfs.android.contentpal.tools.uriparams.AccountScopedParams;
 import org.dmfs.jems.optional.Optional;
 
 
 /**
- * A {@link View} filtered by account. This only works for view that support the {@code account_name} and {@code account_type} query parameters.
+ * A {@link View} filtered by account. This only works for views that support have {@code account_name} and {@code account_type} columns.
  *
  * @param <T>
  *         The contract of this view.
@@ -57,7 +56,7 @@ public final class AccountScoped<T> implements View<T>
     @Override
     public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(new AccountScopedParams(mAccount, uriParams), projection, new AllOf(predicate, new AccountEq(mAccount)), sorting);
+        return mDelegate.rows(uriParams, projection, new AllOf(predicate, new AccountEq(mAccount)), sorting);
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
@@ -16,6 +16,7 @@
 
 package org.dmfs.android.contentpal.views;
 
+import android.accounts.Account;
 import android.database.Cursor;
 import android.os.RemoteException;
 import android.support.annotation.NonNull;
@@ -25,6 +26,7 @@ import org.dmfs.android.contentpal.Projection;
 import org.dmfs.android.contentpal.Table;
 import org.dmfs.android.contentpal.UriParams;
 import org.dmfs.android.contentpal.View;
+import org.dmfs.android.contentpal.tools.uriparams.AccountScopedParams;
 import org.dmfs.android.contentpal.tools.uriparams.SyncParams;
 import org.dmfs.jems.optional.Optional;
 
@@ -40,11 +42,13 @@ import org.dmfs.jems.optional.Optional;
  */
 public final class Synced<T> implements View<T>
 {
+    private final Account mAccount;
     private final View<T> mDelegate;
 
 
-    public Synced(@NonNull View<T> delegate)
+    public Synced(@NonNull Account account, @NonNull View<T> delegate)
     {
+        mAccount = account;
         mDelegate = delegate;
     }
 
@@ -53,7 +57,7 @@ public final class Synced<T> implements View<T>
     @Override
     public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(new SyncParams(uriParams), projection, predicate, sorting);
+        return mDelegate.rows(new AccountScopedParams(mAccount, new SyncParams(uriParams)), projection, predicate, sorting);
     }
 
 
@@ -61,6 +65,6 @@ public final class Synced<T> implements View<T>
     @Override
     public Table<T> table()
     {
-        return new org.dmfs.android.contentpal.tables.Synced<>(mDelegate.table());
+        return new org.dmfs.android.contentpal.tables.Synced<>(mAccount, mDelegate.table());
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/views/SyncedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/views/SyncedTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.views;
+
+import android.accounts.Account;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.RemoteException;
+import android.provider.ContactsContract;
+
+import org.dmfs.android.contentpal.Operation;
+import org.dmfs.android.contentpal.Predicate;
+import org.dmfs.android.contentpal.Projection;
+import org.dmfs.android.contentpal.UriParams;
+import org.dmfs.android.contentpal.View;
+import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Test @{@link Synced}.
+ *
+ * @author Marten Gajda
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class SyncedTest
+{
+    @Test
+    public void test() throws RemoteException
+    {
+        Cursor dummyResult = dummy(Cursor.class);
+        Predicate dummyPredicate = dummy(Predicate.class);
+        Projection<Object> dummyProjection = dummy(Projection.class);
+        View<Object> mockView = failingMock(View.class);
+        Account account = new Account("name", "type");
+        doReturn(dummyResult).when(mockView)
+                .rows(argThat(new UriParamsArgumentMatcher(account)), same(dummyProjection), same(dummyPredicate), any(Optional.class));
+
+        assertThat(new Synced<>(account, mockView).rows(new EmptyUriParams(), dummyProjection, dummyPredicate, new Present<>("sorting")),
+                sameInstance(dummyResult));
+    }
+
+
+    private static class UriParamsArgumentMatcher implements ArgumentMatcher<UriParams>
+    {
+        private final Account mAccount;
+
+
+        private UriParamsArgumentMatcher(Account account)
+        {
+            mAccount = account;
+        }
+
+
+        @Override
+        public boolean matches(UriParams argument)
+        {
+            Uri uri = argument.withParam(new Uri.Builder()).build();
+            return uri.getBooleanQueryParameter(ContactsContract.CALLER_IS_SYNCADAPTER, false) &&
+                    mAccount.equals(new Account(uri.getQueryParameter("account_name"), uri.getQueryParameter("account_type")));
+        }
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,7 @@ ext.deps = [
 
         junit              : 'junit:junit:4.12',
         hamcrest           : 'org.hamcrest:hamcrest-library:1.3',
-        mockito            : 'org.mockito:mockito-core:2.10.0',
-        roboelectric       : 'org.robolectric:robolectric:3.1.4'
+        mockito            : 'org.mockito:mockito-core:2.12.0',
+        roboelectric       : 'org.robolectric:robolectric:3.5.1'
 ]
 


### PR DESCRIPTION
As a result, AccountScoped no longer sets the URI params.