### PR TITLE
Add Frozen RowSet, implements #207

### DIFF
--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/RawContactDataRows.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/RawContactDataRows.java
@@ -30,8 +30,8 @@ import org.dmfs.android.contentpal.predicates.AllOf;
 import org.dmfs.android.contentpal.predicates.AnyOf;
 import org.dmfs.android.contentpal.predicates.ReferringTo;
 import org.dmfs.android.contentpal.references.RowSnapshotReference;
-import org.dmfs.android.contentpal.rowsets.Cached;
 import org.dmfs.android.contentpal.rowsets.DelegatingRowSet;
+import org.dmfs.android.contentpal.rowsets.Frozen;
 import org.dmfs.android.contentpal.rowsets.QueryRowSet;
 
 import androidx.annotation.NonNull;
@@ -40,7 +40,7 @@ import androidx.annotation.NonNull;
 /**
  * The {@link RowSet} of the {@link ContactsContract.Data} rows of a specific raw contact.
  * <p>
- * Note, the result is not cached. Iterating this multiple times, will query the content provider each time. Use {@link Cached} to cache the result.
+ * Note, the result is not cached. Iterating this multiple times, will query the content provider each time. Use {@link Frozen} to retain the result.
  *
  * @author Marten Gajda
  */

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/Frozen.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/Frozen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2019 dmfs GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,9 @@ import org.dmfs.android.contentpal.ClosableIterator;
 import org.dmfs.android.contentpal.RowSet;
 import org.dmfs.android.contentpal.RowSnapshot;
 import org.dmfs.android.contentpal.tools.FakeClosable;
+import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.adapters.Unchecked;
 
-import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -29,19 +30,30 @@ import androidx.annotation.NonNull;
 
 
 /**
- * A {@link RowSet} Decorator which caches the content of the decorated {@link RowSet}.
+ * A {@link RowSet} which eagerly evaluates another {@link RowSet}. Iterating over this {@link RowSet} more than once will not cause additional content provider
+ * queries.
  *
  * @author Marten Gajda
  */
-public final class Cached<T> implements RowSet<T>
+public final class Frozen<T> implements RowSet<T>
 {
-    private final RowSet<T> mDelegate;
-    private List<RowSnapshot<T>> mSnapshots;
+    private final Single<Iterable<RowSnapshot<T>>> mDelegate;
 
 
-    public Cached(@NonNull RowSet<T> delegate)
+    public Frozen(@NonNull RowSet<T> delegate)
     {
-        mDelegate = delegate;
+        mDelegate = new org.dmfs.jems.single.elementary.Frozen<>(new Unchecked<>(() -> {
+            try (ClosableIterator<RowSnapshot<T>> iterator = delegate.iterator())
+            {
+                List<RowSnapshot<T>> result = new LinkedList<>();
+
+                while (iterator.hasNext())
+                {
+                    result.add(iterator.next());
+                }
+                return result;
+            }
+        }));
     }
 
 
@@ -49,26 +61,6 @@ public final class Cached<T> implements RowSet<T>
     @Override
     public ClosableIterator<RowSnapshot<T>> iterator()
     {
-        if (mSnapshots == null)
-        {
-            // pull all the snapshots
-            try (ClosableIterator<RowSnapshot<T>> iterator = mDelegate.iterator())
-            {
-                List<RowSnapshot<T>> snapshots = new LinkedList<>();
-
-                while (iterator.hasNext())
-                {
-                    snapshots.add(iterator.next());
-                }
-
-                mSnapshots = snapshots;
-
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeException("IOException without doing any IO");
-            }
-        }
-        return new FakeClosable<>(mSnapshots.iterator());
+        return new FakeClosable<>(mDelegate.value().iterator());
     }
 }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/rowsets/FrozenTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/rowsets/FrozenTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.android.contentpal.rowsets;
+
+import org.dmfs.android.contentpal.ClosableIterator;
+import org.dmfs.android.contentpal.RowSnapshot;
+import org.dmfs.android.contentpal.testing.table.Contract;
+import org.dmfs.android.contentpal.tools.FakeClosable;
+import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.iterators.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class FrozenTest
+{
+    @Test
+    public void testEmpty()
+    {
+        ClosableIterator<RowSnapshot<Contract>> delegate = new FakeClosable<>(new EmptyIterator<>());
+        assertThat(new Frozen<>(() -> delegate), allOf(emptyIterable(), emptyIterable(), emptyIterable()));
+    }
+
+
+    @Test
+    public void testSingleRow()
+    {
+        RowSnapshot<Contract> dummy1 = dummy(RowSnapshot.class);
+        ClosableIterator<RowSnapshot<Contract>> delegate = new FakeClosable<>(new Seq<>(dummy1));
+        assertThat(new Frozen<>(() -> delegate), allOf(iteratesTo(dummy1), iteratesTo(dummy1), iteratesTo(dummy1)));
+    }
+
+
+    @Test
+    public void test2Rows()
+    {
+        RowSnapshot<Contract> dummy1 = dummy(RowSnapshot.class);
+        RowSnapshot<Contract> dummy2 = dummy(RowSnapshot.class);
+        ClosableIterator<RowSnapshot<Contract>> delegate = new FakeClosable<>(new Seq<>(dummy1, dummy2));
+        assertThat(new Frozen<>(() -> delegate), allOf(iteratesTo(dummy1, dummy2), iteratesTo(dummy1, dummy2), iteratesTo(dummy1, dummy2)));
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,4 @@
-def jems_version = '1.22'
+def jems_version = '1.23'
 def hamcrest_version = '1.3'
 
 ext.deps = [


### PR DESCRIPTION
This replaces the Cached RowSet decorator with a Frozen RowSet decorator. The new name and implementation are considered cleaner than the old one.