### PR TITLE
Bind predicates to contract by making them generic, implements #185

### DIFF
--- a/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
+++ b/app/src/main/java/org/dmfs/contentpal/demo/DemoActivity.java
@@ -344,7 +344,7 @@ public class DemoActivity extends AppCompatActivity
         }
 
         mCalendarQueue.enqueue(
-                new SingletonIterable<>(new BulkDelete<>(mCalendars, new AllOf())));
+                new SingletonIterable<>(new BulkDelete<>(mCalendars, new AllOf<>())));
         mCalendarQueue.flush();
     }
 

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/predicates/CalendarScoped.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/predicates/CalendarScoped.java
@@ -32,10 +32,10 @@ import androidx.annotation.NonNull;
  *
  * @author Gabor Keszthelyi
  */
-public final class CalendarScoped extends DelegatingPredicate
+public final class CalendarScoped extends DelegatingPredicate<CalendarContract.Events>
 {
-    public CalendarScoped(@NonNull RowSnapshot<CalendarContract.Calendars> calendarRow, @NonNull Predicate predicate)
+    public CalendarScoped(@NonNull RowSnapshot<CalendarContract.Calendars> calendarRow, @NonNull Predicate<? super CalendarContract.Events> predicate)
     {
-        super(new AllOf(predicate, new ReferringTo<>(CalendarContract.Events.CALENDAR_ID, calendarRow)));
+        super(new AllOf<>(predicate, new ReferringTo<>(CalendarContract.Events.CALENDAR_ID, calendarRow)));
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/predicates/TransientEvent.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/predicates/TransientEvent.java
@@ -30,13 +30,13 @@ import org.dmfs.android.contentpal.predicates.IsNull;
  *
  * @author Marten Gajda
  */
-public final class TransientEvent extends DelegatingPredicate
+public final class TransientEvent extends DelegatingPredicate<CalendarContract.Events>
 {
     public TransientEvent()
     {
-        super(new AllOf(
-                new IsNull(CalendarContract.Events.ORIGINAL_SYNC_ID),
-                new IsNull(CalendarContract.Events._SYNC_ID),
-                new EqArg(CalendarContract.Events.DELETED, 1)));
+        super(new AllOf<>(
+                new IsNull<>(CalendarContract.Events.ORIGINAL_SYNC_ID),
+                new IsNull<>(CalendarContract.Events._SYNC_ID),
+                new EqArg<>(CalendarContract.Events.DELETED, 1)));
     }
 }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/tables/CalendarScoped.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/tables/CalendarScoped.java
@@ -69,7 +69,7 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
 
     @NonNull
     @Override
-    public Operation<CalendarContract.Events> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<CalendarContract.Events> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super CalendarContract.Events> predicate)
     {
         return mDelegate.updateOperation(uriParams, calendarScoped(predicate));
     }
@@ -77,7 +77,7 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
 
     @NonNull
     @Override
-    public Operation<CalendarContract.Events> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<CalendarContract.Events> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super CalendarContract.Events> predicate)
     {
         return mDelegate.deleteOperation(uriParams, calendarScoped(predicate));
     }
@@ -85,7 +85,7 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
 
     @NonNull
     @Override
-    public Operation<CalendarContract.Events> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<CalendarContract.Events> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super CalendarContract.Events> predicate)
     {
         return mDelegate.assertOperation(uriParams, calendarScoped(predicate));
     }
@@ -99,7 +99,7 @@ public final class CalendarScoped implements Table<CalendarContract.Events>
     }
 
 
-    private Predicate calendarScoped(@NonNull Predicate predicate)
+    private Predicate<? super CalendarContract.Events> calendarScoped(@NonNull Predicate<? super CalendarContract.Events> predicate)
     {
         return new org.dmfs.android.calendarpal.predicates.CalendarScoped(mCalendarRow, predicate);
     }

--- a/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/CalendarScoped.java
+++ b/calendarpal/src/main/java/org/dmfs/android/calendarpal/views/CalendarScoped.java
@@ -69,7 +69,7 @@ public final class CalendarScoped implements View<CalendarContract.Events>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super CalendarContract.Events> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super CalendarContract.Events> projection, @NonNull Predicate<? super CalendarContract.Events> predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(
                 uriParams,

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/predicates/CalendarScopedPredicateTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/predicates/CalendarScopedPredicateTest.java
@@ -57,7 +57,7 @@ public final class CalendarScopedPredicateTest
         doReturn(dummyReference).when(mockCalendarRow).reference();
         doReturn(new BackReference<>(dummy(Uri.class), 12)).when(mockTc).resolved(dummyReference);
 
-        assertThat(new CalendarScoped(mockCalendarRow, new EqArg("x", "y")),
+        assertThat(new CalendarScoped(mockCalendarRow, new EqArg<>("x", "y")),
                 predicateWith(
                         selection(mockTc, "( x = ? ) and ( calendar_id = ? )"),
                         argumentValues(mockTc, "y", "-1"),

--- a/calendarpal/src/test/java/org/dmfs/android/calendarpal/predicates/TransientEventTest.java
+++ b/calendarpal/src/test/java/org/dmfs/android/calendarpal/predicates/TransientEventTest.java
@@ -18,6 +18,7 @@ package org.dmfs.android.calendarpal.predicates;
 
 import android.provider.CalendarContract;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.absentBackReferences;
@@ -25,7 +26,6 @@ import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.ar
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.predicateWith;
 import static org.dmfs.android.contentpal.testing.predicates.PredicateMatcher.selection;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 
 /**
@@ -39,7 +39,7 @@ public class TransientEventTest
     public void test()
     {
         assertThat(new TransientEvent(),
-                is(predicateWith(
+                Matchers.is(predicateWith(
                         selection(String.format("( %s is null ) and ( %s is null ) and ( %s = ? )",
                                 CalendarContract.Events.ORIGINAL_SYNC_ID,
                                 CalendarContract.Events._SYNC_ID,

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationException.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/aggregation/AggregationException.java
@@ -70,7 +70,7 @@ final class AggregationException implements Operation<ContactsContract.Aggregati
                         transactionContext,
                         AggregationExceptions.INSTANCE.updateOperation(
                                 EmptyUriParams.INSTANCE,
-                                new AnyOf()
+                                new AnyOf<>()
                         ).contentOperationBuilder(transactionContext),
                         ContactsContract.AggregationExceptions.RAW_CONTACT_ID1), ContactsContract.AggregationExceptions.RAW_CONTACT_ID2);
 

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/predicates/TransientRawContact.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/predicates/TransientRawContact.java
@@ -30,12 +30,12 @@ import org.dmfs.android.contentpal.predicates.IsNull;
  *
  * @author Marten Gajda
  */
-public final class TransientRawContact extends DelegatingPredicate
+public final class TransientRawContact extends DelegatingPredicate<ContactsContract.RawContacts>
 {
     public TransientRawContact()
     {
-        super(new AllOf(
-                new IsNull(ContactsContract.RawContacts.SOURCE_ID),
-                new EqArg(ContactsContract.RawContacts.DELETED, 1)));
+        super(new AllOf<>(
+                new IsNull<>(ContactsContract.RawContacts.SOURCE_ID),
+                new EqArg<>(ContactsContract.RawContacts.DELETED, 1)));
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Dirty.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Dirty.java
@@ -41,9 +41,9 @@ public final class Dirty extends DelegatingRowSet<ContactsContract.RawContacts>
     {
         super(new QueryRowSet<>(mRawContacts,
                 projection,
-                new AnyOf(
-                        new EqArg(ContactsContract.RawContacts.DIRTY, 1),
-                        new EqArg(ContactsContract.RawContacts.DELETED, 1))));
+                new AnyOf<>(
+                        new EqArg<>(ContactsContract.RawContacts.DIRTY, 1),
+                        new EqArg<>(ContactsContract.RawContacts.DELETED, 1))));
     }
 
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/RawContactDataRows.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/RawContactDataRows.java
@@ -56,7 +56,7 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      */
     public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact)
     {
-        this(dataView, projection, rawContact, new AnyOf());
+        this(dataView, projection, rawContact, new AnyOf<>());
     }
 
 
@@ -70,7 +70,7 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      */
     public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowReference<ContactsContract.RawContacts> rawContact)
     {
-        this(dataView, projection, rawContact, new AnyOf());
+        this(dataView, projection, rawContact, new AnyOf<>());
     }
 
 
@@ -84,7 +84,7 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      * @param predicate
      *         A {@link Predicate} to filter the data rows to return.
      */
-    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact, @NonNull Predicate predicate)
+    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowSnapshot<ContactsContract.RawContacts> rawContact, @NonNull Predicate<? super ContactsContract.Data> predicate)
     {
         this(dataView, projection, new RowSnapshotReference<>(rawContact), predicate);
     }
@@ -100,13 +100,13 @@ public final class RawContactDataRows extends DelegatingRowSet<ContactsContract.
      * @param predicate
      *         A {@link Predicate} to filter the data rows to return.
      */
-    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowReference<ContactsContract.RawContacts> rawContactReference, @NonNull Predicate predicate)
+    public RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull RowReference<ContactsContract.RawContacts> rawContactReference, @NonNull Predicate<? super ContactsContract.Data> predicate)
     {
-        this(dataView, projection, new AllOf(new ReferringTo<>(BaseColumns._ID, rawContactReference), predicate));
+        this(dataView, projection, new AllOf<>(new ReferringTo<>(BaseColumns._ID, rawContactReference), predicate));
     }
 
 
-    private RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull Predicate predicate)
+    private RawContactDataRows(@NonNull View<ContactsContract.Data> dataView, @NonNull Projection<ContactsContract.Data> projection, @NonNull Predicate<? super ContactsContract.Data> predicate)
     {
         super(new QueryRowSet<>(dataView, projection, predicate));
     }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Unsynced.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/rowsets/Unsynced.java
@@ -38,7 +38,7 @@ public final class Unsynced extends DelegatingRowSet<ContactsContract.RawContact
 
     public Unsynced(@NonNull View<ContactsContract.RawContacts> mRawContacts, @NonNull Projection<ContactsContract.RawContacts> projection)
     {
-        super(new QueryRowSet<>(mRawContacts, projection, new IsNull(ContactsContract.RawContacts.SOURCE_ID)));
+        super(new QueryRowSet<>(mRawContacts, projection, new IsNull<>(ContactsContract.RawContacts.SOURCE_ID)));
     }
 
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/AggregationExceptions.java
@@ -58,7 +58,7 @@ public final class AggregationExceptions implements Table<ContactsContract.Aggre
 
     @NonNull
     @Override
-    public Operation<ContactsContract.AggregationExceptions> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<ContactsContract.AggregationExceptions> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super ContactsContract.AggregationExceptions> predicate)
     {
         return mDelegate.updateOperation(uriParams, predicate);
     }
@@ -66,7 +66,7 @@ public final class AggregationExceptions implements Table<ContactsContract.Aggre
 
     @NonNull
     @Override
-    public Operation<ContactsContract.AggregationExceptions> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<ContactsContract.AggregationExceptions> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super ContactsContract.AggregationExceptions> predicate)
     {
         throw new UnsupportedOperationException("AggregationExceptions doesn't support deletes");
     }
@@ -74,7 +74,7 @@ public final class AggregationExceptions implements Table<ContactsContract.Aggre
 
     @NonNull
     @Override
-    public Operation<ContactsContract.AggregationExceptions> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<ContactsContract.AggregationExceptions> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super ContactsContract.AggregationExceptions> predicate)
     {
         return mDelegate.assertOperation(uriParams, predicate);
     }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/tables/Local.java
@@ -62,7 +62,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
 
     @NonNull
     @Override
-    public Operation<ContactsContract.RawContacts> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<ContactsContract.RawContacts> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super ContactsContract.RawContacts> predicate)
     {
         return mDelegate.updateOperation(uriParams, localAccountPredicate(predicate));
     }
@@ -70,7 +70,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
 
     @NonNull
     @Override
-    public Operation<ContactsContract.RawContacts> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<ContactsContract.RawContacts> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super ContactsContract.RawContacts> predicate)
     {
         return mDelegate.deleteOperation(uriParams, localAccountPredicate(predicate));
     }
@@ -78,7 +78,7 @@ public final class Local implements Table<ContactsContract.RawContacts>
 
     @NonNull
     @Override
-    public Operation<ContactsContract.RawContacts> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<ContactsContract.RawContacts> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super ContactsContract.RawContacts> predicate)
     {
         return mDelegate.assertOperation(uriParams, localAccountPredicate(predicate));
     }
@@ -92,8 +92,8 @@ public final class Local implements Table<ContactsContract.RawContacts>
     }
 
 
-    private Predicate localAccountPredicate(@NonNull Predicate predicate)
+    private Predicate<? super ContactsContract.RawContacts> localAccountPredicate(@NonNull Predicate<? super ContactsContract.RawContacts> predicate)
     {
-        return new AllOf(predicate, new IsNull("account_name"), new IsNull("account_type"));
+        return new AllOf<>(predicate, new IsNull<>("account_name"), new IsNull<>("account_type"));
     }
 }

--- a/contactspal/src/main/java/org/dmfs/android/contactspal/views/Local.java
+++ b/contactspal/src/main/java/org/dmfs/android/contactspal/views/Local.java
@@ -54,11 +54,12 @@ public final class Local implements View<ContactsContract.RawContacts>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super ContactsContract.RawContacts> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super ContactsContract.RawContacts> projection, @NonNull Predicate<? super ContactsContract.RawContacts> predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(uriParams,
                 projection,
-                new AllOf(predicate, new IsNull(ContactsContract.RawContacts.ACCOUNT_NAME), new IsNull(ContactsContract.RawContacts.ACCOUNT_TYPE)), sorting);
+                new AllOf<>(predicate, new IsNull<>(ContactsContract.RawContacts.ACCOUNT_NAME), new IsNull<>(ContactsContract.RawContacts.ACCOUNT_TYPE)),
+                sorting);
     }
 
 

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/Predicate.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/Predicate.java
@@ -24,9 +24,12 @@ import androidx.annotation.NonNull;
 /**
  * A predicate.
  *
+ * @param <Contract>
+ *         The contract of the table this predicate belongs to.
+ *
  * @author Marten Gajda
  */
-public interface Predicate
+public interface Predicate<Contract>
 {
     /**
      * A selection argument.

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/RowReference.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/RowReference.java
@@ -93,5 +93,5 @@ public interface RowReference<T>
      * @return A {@link Predicate}
      */
     @NonNull
-    Predicate predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn);
+    Predicate<T> predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn);
 }

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/Table.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/Table.java
@@ -53,7 +53,7 @@ public interface Table<T>
      * @return An {@link Operation} for this table.
      */
     @NonNull
-    Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate);
+    Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate);
 
     /**
      * Returns an {@link Operation} to delete rows of this table.
@@ -64,7 +64,7 @@ public interface Table<T>
      * @return An {@link Operation} for this table.
      */
     @NonNull
-    Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate);
+    Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate);
 
     /**
      * Returns an {@link Operation} to assert rows of this table.
@@ -76,7 +76,7 @@ public interface Table<T>
      * @return An {@link Operation} for this table.
      */
     @NonNull
-    Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate);
+    Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate);
 
     /**
      * Returns a {@link View} on this table.

--- a/contentpal-api/src/main/java/org/dmfs/android/contentpal/View.java
+++ b/contentpal-api/src/main/java/org/dmfs/android/contentpal/View.java
@@ -53,7 +53,7 @@ public interface View<T>
      * @return A {@link Cursor} as returned by the {@link ContentProvider}.
      */
     @NonNull
-    Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException;
+    Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate<? super T> predicate, @NonNull Optional<String> sorting) throws RemoteException;
 
     /**
      * Returns a {@link Table} to write to.

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/Mocked.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/Mocked.java
@@ -31,7 +31,7 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class Mocked implements Predicate
+public final class Mocked<Contract> implements Predicate<Contract>
 {
 
     private final CharSequence mSelection;

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateArgumentMatcher.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateArgumentMatcher.java
@@ -35,16 +35,16 @@ import static org.dmfs.jems.optional.elementary.Absent.absent;
 public final class PredicateArgumentMatcher
 {
     @NonNull
-    public static Predicate predicateWithSelection(@NonNull CharSequence expectedSelection)
+    public static <T> Predicate<? super T> predicateWithSelection(@NonNull CharSequence expectedSelection)
     {
-        return MockitoHamcrest.argThat(new PredicateMatcher.Selection(absent(), expectedSelection));
+        return MockitoHamcrest.argThat(new PredicateMatcher.Selection<>(absent(), expectedSelection));
     }
 
 
     @NonNull
-    public static Predicate predicateWithSelection(@NonNull TransactionContext tc, @NonNull CharSequence expectedSelection)
+    public static <T> Predicate<? super T> predicateWithSelection(@NonNull TransactionContext tc, @NonNull CharSequence expectedSelection)
     {
-        return MockitoHamcrest.argThat(new PredicateMatcher.Selection(new Present<>(tc), expectedSelection));
+        return MockitoHamcrest.argThat(new PredicateMatcher.Selection<>(new Present<>(tc), expectedSelection));
     }
 
 

--- a/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcher.java
+++ b/contentpal-testing/src/main/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcher.java
@@ -49,7 +49,7 @@ public final class PredicateMatcher
     @NonNull
     @SafeVarargs
     @Factory
-    public static Matcher<Predicate> predicateWith(@NonNull Matcher<Predicate>... matchers)
+    public static <T> Matcher<Predicate<? super T>> predicateWith(@NonNull Matcher<Predicate<? super T>>... matchers)
     {
         return CoreMatchers.allOf(matchers);
     }
@@ -57,87 +57,87 @@ public final class PredicateMatcher
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> selection(@NonNull CharSequence selection)
+    public static <T> Matcher<Predicate<? super T>> selection(@NonNull CharSequence selection)
     {
-        return new Selection(absent(), selection);
+        return new Selection<>(absent(), selection);
     }
 
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> selection(@NonNull TransactionContext tc, @NonNull CharSequence selection)
+    public static <T> Matcher<Predicate<? super T>> selection(@NonNull TransactionContext tc, @NonNull CharSequence selection)
     {
-        return new Selection(new Present<>(tc), selection);
+        return new Selection<>(new Present<>(tc), selection);
     }
 
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> emptyArguments()
+    public static <T> Matcher<Predicate<? super T>> emptyArguments()
     {
-        return new EmptyArgument(absent());
+        return new EmptyArgument<>(absent());
     }
 
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> emptyArguments(@NonNull TransactionContext tc)
+    public static <T> Matcher<Predicate<? super T>> emptyArguments(@NonNull TransactionContext tc)
     {
-        return new EmptyArgument(new Present<>(tc));
+        return new EmptyArgument<>(new Present<>(tc));
     }
 
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> argumentValues(@NonNull String... values)
+    public static <T> Matcher<Predicate<? super T>> argumentValues(@NonNull String... values)
     {
-        return new ArgumentValues(absent(), values);
+        return new ArgumentValues<>(absent(), values);
     }
 
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> argumentValues(@NonNull TransactionContext tc, @NonNull String... values)
+    public static <T> Matcher<Predicate<? super T>> argumentValues(@NonNull TransactionContext tc, @NonNull String... values)
     {
-        return new ArgumentValues(new Present<>(tc), values);
-    }
-
-
-    @NonNull
-    @Factory
-    @SafeVarargs
-    public static Matcher<Predicate> backReferences(@NonNull Matcher<Optional<Integer>>... backReferences)
-    {
-        return new ArgumentBackReferences(absent(), backReferences);
+        return new ArgumentValues<>(new Present<>(tc), values);
     }
 
 
     @NonNull
     @Factory
     @SafeVarargs
-    public static Matcher<Predicate> backReferences(TransactionContext tc, Matcher<Optional<Integer>>... backReferences)
+    public static <T> Matcher<Predicate<? super T>> backReferences(@NonNull Matcher<Optional<Integer>>... backReferences)
     {
-        return new ArgumentBackReferences(new Present<>(tc), backReferences);
+        return new ArgumentBackReferences<>(absent(), backReferences);
     }
 
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> absentBackReferences(int noOfPredicateArguments)
+    @SafeVarargs
+    public static <T> Matcher<Predicate<? super T>> backReferences(TransactionContext tc, Matcher<Optional<Integer>>... backReferences)
     {
-        Matcher[] matchers = new Matcher[noOfPredicateArguments];
-        Arrays.fill(matchers, AbsentMatcher.absent());
-        return new ArgumentBackReferences(absent(), matchers);
+        return new ArgumentBackReferences<>(new Present<>(tc), backReferences);
     }
 
 
     @NonNull
     @Factory
-    public static Matcher<Predicate> absentBackReferences(@NonNull TransactionContext tc, int noOfPredicateArguments)
+    public static <T> Matcher<Predicate<? super T>> absentBackReferences(int noOfPredicateArguments)
     {
         Matcher[] matchers = new Matcher[noOfPredicateArguments];
         Arrays.fill(matchers, AbsentMatcher.absent());
-        return new ArgumentBackReferences(new Present<>(tc), matchers);
+        return new ArgumentBackReferences<>(absent(), matchers);
+    }
+
+
+    @NonNull
+    @Factory
+    public static <T> Matcher<Predicate<? super T>> absentBackReferences(@NonNull TransactionContext tc, int noOfPredicateArguments)
+    {
+        Matcher[] matchers = new Matcher[noOfPredicateArguments];
+        Arrays.fill(matchers, AbsentMatcher.absent());
+        return new ArgumentBackReferences<>(new Present<>(tc), matchers);
     }
 
 
@@ -147,7 +147,7 @@ public final class PredicateMatcher
     }
 
 
-    static final class Selection extends FeatureMatcher<Predicate, CharSequence>
+    static final class Selection<T> extends FeatureMatcher<Predicate<? super T>, CharSequence>
     {
         private final Optional<TransactionContext> mTc;
 
@@ -160,14 +160,14 @@ public final class PredicateMatcher
 
 
         @Override
-        protected CharSequence featureValueOf(@NonNull Predicate actual)
+        protected CharSequence featureValueOf(@NonNull Predicate<? super T> actual)
         {
             return actual.selection(new Backed<>(mTc, dummy(TransactionContext.class)).value());
         }
     }
 
 
-    private static final class ArgumentValues extends FeatureMatcher<Predicate, Iterable<String>>
+    private static final class ArgumentValues<T> extends FeatureMatcher<Predicate<? super T>, Iterable<String>>
     {
 
         private final Optional<TransactionContext> mTc;
@@ -181,14 +181,14 @@ public final class PredicateMatcher
 
 
         @Override
-        protected Iterable<String> featureValueOf(Predicate predicate)
+        protected Iterable<String> featureValueOf(Predicate<? super T> predicate)
         {
             return new Mapped<>(Predicate.Argument::value, predicate.arguments(new Backed<>(mTc, dummy(TransactionContext.class)).value()));
         }
     }
 
 
-    private static final class EmptyArgument extends FeatureMatcher<Predicate, Iterable<Predicate.Argument>>
+    private static final class EmptyArgument<T> extends FeatureMatcher<Predicate<? super T>, Iterable<Predicate.Argument>>
     {
 
         private final Optional<TransactionContext> mTc;
@@ -202,14 +202,14 @@ public final class PredicateMatcher
 
 
         @Override
-        protected Iterable<Predicate.Argument> featureValueOf(Predicate predicate)
+        protected Iterable<Predicate.Argument> featureValueOf(Predicate<? super T> predicate)
         {
             return predicate.arguments(new Backed<>(mTc, dummy(TransactionContext.class)).value());
         }
     }
 
 
-    private static final class ArgumentBackReferences extends FeatureMatcher<Predicate, Iterable<Optional<Integer>>>
+    private static final class ArgumentBackReferences<T> extends FeatureMatcher<Predicate<? super T>, Iterable<Optional<Integer>>>
     {
 
         private final Optional<TransactionContext> mTc;
@@ -224,7 +224,7 @@ public final class PredicateMatcher
 
 
         @Override
-        protected Iterable<Optional<Integer>> featureValueOf(Predicate predicate)
+        protected Iterable<Optional<Integer>> featureValueOf(Predicate<? super T> predicate)
         {
             return new Mapped<>(Predicate.Argument::backReference, predicate.arguments(new Backed<>(mTc, dummy(TransactionContext.class)).value()));
         }

--- a/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/android/uri/UriMatcherTest.java
+++ b/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/android/uri/UriMatcherTest.java
@@ -18,6 +18,7 @@ package org.dmfs.android.contentpal.testing.android.uri;
 
 import android.net.Uri;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -35,7 +36,6 @@ import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -53,43 +53,43 @@ public class UriMatcherTest
     public void test()
     {
         assertThat(absolute(),
-                allOf(matches(Uri.parse("https://example.com")),
+                Matchers.<org.hamcrest.Matcher<Uri>>allOf(matches(Uri.parse("https://example.com")),
                         matches(Uri.parse("mailto:mail@example.com")),
                         mismatches(Uri.parse("non/absolute"), "absolute was <false>"),
                         describesAs("absolute is <true>")));
 
         assertThat(hierarchical(),
-                allOf(matches(Uri.parse("https://example.com")),
+                Matchers.<org.hamcrest.Matcher<Uri>>allOf(matches(Uri.parse("https://example.com")),
                         matches(Uri.parse("non/absolute")),
                         mismatches(Uri.parse("mailto:mail@example.com"), "hierarchical was <false>"),
                         describesAs("hierarchical is <true>")));
 
         assertThat(encodedPath("/abc/def%20123"),
-                allOf(matches(Uri.parse("https://example.com/abc/def%20123")),
+                Matchers.<org.hamcrest.Matcher<Uri>>allOf(matches(Uri.parse("https://example.com/abc/def%20123")),
                         matches(Uri.parse("/abc/def%20123")),
                         mismatches(Uri.parse("https://example.com/abc/def%21123"), "path was \"/abc/def%21123\""),
                         describesAs("path is \"/abc/def%20123\"")));
 
         assertThat(hasParam("param", "value"),
-                allOf(matches(Uri.parse("https://example.com/?param=value")),
+                Matchers.<org.hamcrest.Matcher<Uri>>allOf(matches(Uri.parse("https://example.com/?param=value")),
                         mismatches(Uri.parse("https://example.com/"), "parameter \"param\" was null"),
                         mismatches(Uri.parse("https://example.com/?param=value1"), "parameter \"param\" was \"value1\""),
                         describesAs("parameter \"param\" is \"value\"")));
 
         assertThat(hasParam("param", is("value")),
-                allOf(matches(Uri.parse("https://example.com/?param=value")),
+                Matchers.<org.hamcrest.Matcher<Uri>>allOf(matches(Uri.parse("https://example.com/?param=value")),
                         mismatches(Uri.parse("https://example.com/"), "parameter \"param\" was null"),
                         mismatches(Uri.parse("https://example.com/?param=value1"), "parameter \"param\" was \"value1\""),
                         describesAs("parameter \"param\" is \"value\"")));
 
         assertThat(hasParamSet(is(emptyIterable())),
-                allOf(matches(Uri.parse("https://example.com/")),
+                Matchers.<org.hamcrest.Matcher<Uri>>allOf(matches(Uri.parse("https://example.com/")),
                         mismatches(Uri.parse("https://example.com/?param"), startsWith("parameters ")),
                         mismatches(Uri.parse("https://example.com/?param=value1"), startsWith("parameters ")),
                         describesAs("parameters is an empty iterable")));
 
         assertThat(hasParamSet(containsInAnyOrder(pair("a", "1"), pair("b", "2"))),
-                allOf(matches(Uri.parse("https://example.com/?a=1&b=2")),
+                Matchers.<org.hamcrest.Matcher<Uri>>allOf(matches(Uri.parse("https://example.com/?a=1&b=2")),
                         matches(Uri.parse("https://example.com/?b=2&a=1")),
                         mismatches(Uri.parse("https://example.com/?a=1"), startsWith("parameters ")),
                         mismatches(Uri.parse("https://example.com/?a=1&b=2&c=3"), startsWith("parameters ")),

--- a/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcherTest.java
+++ b/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/predicates/PredicateMatcherTest.java
@@ -143,7 +143,7 @@ public final class PredicateMatcherTest
     @Test
     public void testCombined()
     {
-        Predicate predicateMock = failingMock(Predicate.class);
+        Predicate<Object> predicateMock = failingMock(Predicate.class);
         Predicate.Argument argumentMock = failingMock(Predicate.Argument.class);
 
         doReturn("sel").when(predicateMock).selection(any(TransactionContext.class));

--- a/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/projection/ProjectionMatcherTest.java
+++ b/contentpal-testing/src/test/java/org/dmfs/android/contentpal/testing/projection/ProjectionMatcherTest.java
@@ -20,8 +20,6 @@ import org.dmfs.android.contentpal.Projection;
 import org.hamcrest.Description;
 import org.hamcrest.StringDescription;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projects;
 import static org.dmfs.android.contentpal.testing.projection.ProjectionMatcher.projectsEmpty;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkAssert.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkAssert.java
@@ -43,10 +43,10 @@ public final class BulkAssert<T> implements Operation<T>
 {
     private final Table<T> mTable;
     private final RowData<T> mRowData;
-    private final Predicate mPredicate;
+    private final Predicate<? super T> mPredicate;
 
 
-    public BulkAssert(@NonNull Table<T> table, @NonNull RowData<T> rowData, @NonNull Predicate predicate)
+    public BulkAssert(@NonNull Table<T> table, @NonNull RowData<T> rowData, @NonNull Predicate<? super T> predicate)
     {
         mTable = table;
         mRowData = rowData;
@@ -56,11 +56,11 @@ public final class BulkAssert<T> implements Operation<T>
 
     public BulkAssert(@NonNull Table<T> table, @NonNull RowData<T> rowData)
     {
-        this(table, rowData, new AnyOf());
+        this(table, rowData, new AnyOf<>());
     }
 
 
-    public BulkAssert(@NonNull Table<T> table, @NonNull Predicate predicate)
+    public BulkAssert(@NonNull Table<T> table, @NonNull Predicate<? super T> predicate)
     {
         this(table, new EmptyRowData<>(), predicate);
     }
@@ -68,7 +68,7 @@ public final class BulkAssert<T> implements Operation<T>
 
     public BulkAssert(@NonNull Table<T> table)
     {
-        this(table, new EmptyRowData<>(), new AnyOf());
+        this(table, new EmptyRowData<>(), new AnyOf<>());
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkDelete.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkDelete.java
@@ -39,16 +39,16 @@ import androidx.annotation.NonNull;
 public final class BulkDelete<T> implements Operation<T>
 {
     private final Table<T> mTable;
-    private final Predicate mPredicate;
+    private final Predicate<? super T> mPredicate;
 
 
     public BulkDelete(@NonNull Table<T> table)
     {
-        this(table, new AnyOf());
+        this(table, new AnyOf<>());
     }
 
 
-    public BulkDelete(@NonNull Table<T> table, @NonNull Predicate predicate)
+    public BulkDelete(@NonNull Table<T> table, @NonNull Predicate<? super T> predicate)
     {
         mTable = table;
         mPredicate = predicate;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkUpdate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/operations/BulkUpdate.java
@@ -42,16 +42,16 @@ public final class BulkUpdate<T> implements Operation<T>
 {
     private final Table<T> mTable;
     private final RowData<T> mData;
-    private final Predicate mPredicate;
+    private final Predicate<? super T> mPredicate;
 
 
     public BulkUpdate(@NonNull Table<T> table, @NonNull RowData<T> data)
     {
-        this(table, data, new AnyOf());
+        this(table, data, new AnyOf<>());
     }
 
 
-    public BulkUpdate(@NonNull Table<T> table, @NonNull RowData<T> data, @NonNull Predicate predicate)
+    public BulkUpdate(@NonNull Table<T> table, @NonNull RowData<T> data, @NonNull Predicate<? super T> predicate)
     {
         mTable = table;
         mData = data;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/AccountEq.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/AccountEq.java
@@ -26,12 +26,12 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class AccountEq extends DelegatingPredicate
+public final class AccountEq<Contract> extends DelegatingPredicate<Contract>
 {
 
     public AccountEq(@NonNull Account account)
     {
-        super(new AllOf(new EqArg("account_name", account.name), new EqArg("account_type", account.type)));
+        super(new AllOf<>(new EqArg<>("account_name", account.name), new EqArg<>("account_type", account.type)));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/AllOf.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/AllOf.java
@@ -27,16 +27,17 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class AllOf extends DelegatingPredicate
+public final class AllOf<Contract> extends DelegatingPredicate<Contract>
 {
-    public AllOf(@NonNull Predicate... predicates)
+    @SafeVarargs
+    public AllOf(@NonNull Predicate<? super Contract>... predicates)
     {
-        super(new BinaryPredicate("and", predicates));
+        super(new BinaryPredicate<>("and", predicates));
     }
 
 
-    public AllOf(@NonNull Iterable<Predicate> predicates)
+    public AllOf(@NonNull Iterable<Predicate<? super Contract>> predicates)
     {
-        super(new BinaryPredicate("and", predicates));
+        super(new BinaryPredicate<>("and", predicates));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/AnyOf.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/AnyOf.java
@@ -27,16 +27,17 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class AnyOf extends DelegatingPredicate
+public final class AnyOf<Contract> extends DelegatingPredicate<Contract>
 {
-    public AnyOf(@NonNull Predicate... predicates)
+    @SafeVarargs
+    public AnyOf(@NonNull Predicate<? super Contract>... predicates)
     {
-        super(new BinaryPredicate("or", predicates));
+        super(new BinaryPredicate<>("or", predicates));
     }
 
 
-    public AnyOf(@NonNull Iterable<Predicate> predicates)
+    public AnyOf(@NonNull Iterable<Predicate<? super Contract>> predicates)
     {
-        super(new BinaryPredicate("or", predicates));
+        super(new BinaryPredicate<>("or", predicates));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/BinaryPredicate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/BinaryPredicate.java
@@ -37,19 +37,20 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class BinaryPredicate implements Predicate
+public final class BinaryPredicate<Contract> implements Predicate<Contract>
 {
-    private final Iterable<Predicate> mPredicates;
+    private final Iterable<Predicate<? super Contract>> mPredicates;
     private final String mOperator;
 
 
-    public BinaryPredicate(@NonNull String operator, @NonNull Predicate... predicates)
+    @SafeVarargs
+    public BinaryPredicate(@NonNull String operator, @NonNull Predicate<? super Contract>... predicates)
     {
         this(operator, new Seq<>(predicates));
     }
 
 
-    public BinaryPredicate(@NonNull String operator, @NonNull Iterable<Predicate> predicates)
+    public BinaryPredicate(@NonNull String operator, @NonNull Iterable<Predicate<? super Contract>> predicates)
     {
         mOperator = operator;
         mPredicates = predicates;
@@ -60,7 +61,7 @@ public final class BinaryPredicate implements Predicate
     @Override
     public CharSequence selection(@NonNull TransactionContext transactionContext)
     {
-        Iterator<Predicate> iterator = mPredicates.iterator();
+        Iterator<Predicate<? super Contract>> iterator = mPredicates.iterator();
         if (!iterator.hasNext())
         {
             return "1";

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/DelegatingPredicate.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/DelegatingPredicate.java
@@ -27,12 +27,12 @@ import androidx.annotation.NonNull;
  *
  * @author Gabor Keszthelyi
  */
-public abstract class DelegatingPredicate implements Predicate
+public abstract class DelegatingPredicate<Contract> implements Predicate<Contract>
 {
-    private final Predicate mDelegate;
+    private final Predicate<Contract> mDelegate;
 
 
-    public DelegatingPredicate(@NonNull Predicate predicate)
+    public DelegatingPredicate(@NonNull Predicate<Contract> predicate)
     {
         mDelegate = predicate;
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqArg.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqArg.java
@@ -29,7 +29,7 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class EqArg implements Predicate
+public final class EqArg<Contract> implements Predicate<Contract>
 {
     private final String mColumnName;
     private final Object mArgument;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqCol.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/EqCol.java
@@ -26,7 +26,7 @@ import androidx.annotation.NonNull;
 /**
  * @author Marten Gajda
  */
-public final class EqCol implements Predicate
+public final class EqCol<Contract> implements Predicate<Contract>
 {
     private final String mColumn1Name;
     private final String mColumn2Name;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/IdIn.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/IdIn.java
@@ -29,23 +29,23 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class IdIn extends DelegatingPredicate
+public final class IdIn<Contract> extends DelegatingPredicate<Contract>
 {
     public IdIn(@NonNull String id)
     {
-        super(new EqArg(BaseColumns._ID, id));
+        super(new EqArg<>(BaseColumns._ID, id));
     }
 
 
     public IdIn(@NonNull String... ids)
     {
-        super(new In(BaseColumns._ID, new Seq<>(ids)));
+        super(new In<>(BaseColumns._ID, new Seq<>(ids)));
     }
 
 
     public IdIn(long id)
     {
-        super(new EqArg(BaseColumns._ID, id));
+        super(new EqArg<>(BaseColumns._ID, id));
     }
 
 
@@ -57,6 +57,6 @@ public final class IdIn extends DelegatingPredicate
 
     public IdIn(@NonNull Iterable<Long> ids)
     {
-        super(new In(BaseColumns._ID, ids));
+        super(new In<>(BaseColumns._ID, ids));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/In.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/In.java
@@ -36,7 +36,7 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class In implements Predicate
+public final class In<Contract> implements Predicate<Contract>
 {
     private final String mColumnName;
     private final Iterable<?> mArguments;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/IsNull.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/IsNull.java
@@ -28,7 +28,7 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class IsNull implements Predicate
+public final class IsNull<Contract> implements Predicate<Contract>
 {
     private final String mColumnName;
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/LikeArg.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/LikeArg.java
@@ -29,7 +29,7 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class LikeArg implements Predicate
+public final class LikeArg<Contract> implements Predicate<Contract>
 {
     private final String mColumnName;
     private final Object mArgument;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/NoneOf.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/NoneOf.java
@@ -27,17 +27,18 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class NoneOf extends DelegatingPredicate
+public final class NoneOf<Contract> extends DelegatingPredicate<Contract>
 {
-    public NoneOf(@NonNull Predicate... predicates)
+    @SafeVarargs
+    public NoneOf(@NonNull Predicate<? super Contract>... predicates)
     {
-        super(new Not(new AnyOf(predicates)));
+        super(new Not<>(new AnyOf<>(predicates)));
     }
 
 
-    public NoneOf(@NonNull Iterable<Predicate> predicates)
+    public NoneOf(@NonNull Iterable<Predicate<? super Contract>> predicates)
     {
-        super(new Not(new AnyOf(predicates)));
+        super(new Not<>(new AnyOf<>(predicates)));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/Not.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/Not.java
@@ -25,12 +25,12 @@ import androidx.annotation.NonNull;
 /**
  * @author Marten Gajda
  */
-public final class Not implements Predicate
+public final class Not<Contract> implements Predicate<Contract>
 {
-    private final Predicate mPredicate;
+    private final Predicate<? super Contract> mPredicate;
 
 
-    public Not(@NonNull Predicate predicate)
+    public Not(@NonNull Predicate<? super Contract> predicate)
     {
         mPredicate = predicate;
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/NotNull.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/NotNull.java
@@ -26,7 +26,7 @@ import androidx.annotation.NonNull;
 /**
  * @author Marten Gajda
  */
-public final class NotNull implements Predicate
+public final class NotNull<Contract> implements Predicate<Contract>
 {
     private final String mColumnName;
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/ReferringTo.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/predicates/ReferringTo.java
@@ -30,7 +30,7 @@ import androidx.annotation.NonNull;
  *
  * @author Marten Gajda
  */
-public final class ReferringTo<T> implements Predicate
+public final class ReferringTo<Contract, T> implements Predicate<Contract>
 {
     private final String mColumnName;
     private final RowReference<T> mRowReference;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/AbsoluteRowReference.java
@@ -53,7 +53,7 @@ public final class AbsoluteRowReference<T> implements SoftRowReference<T>
     @Override
     public ContentProviderOperation.Builder putOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mTable.updateOperation(EmptyUriParams.INSTANCE, new EqArg(BaseColumns._ID, rowId())).contentOperationBuilder(transactionContext);
+        return mTable.updateOperation(EmptyUriParams.INSTANCE, new EqArg<>(BaseColumns._ID, rowId())).contentOperationBuilder(transactionContext);
     }
 
 
@@ -61,7 +61,7 @@ public final class AbsoluteRowReference<T> implements SoftRowReference<T>
     @Override
     public ContentProviderOperation.Builder deleteOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mTable.deleteOperation(EmptyUriParams.INSTANCE, new EqArg(BaseColumns._ID, rowId())).contentOperationBuilder(transactionContext);
+        return mTable.deleteOperation(EmptyUriParams.INSTANCE, new EqArg<>(BaseColumns._ID, rowId())).contentOperationBuilder(transactionContext);
     }
 
 
@@ -69,7 +69,7 @@ public final class AbsoluteRowReference<T> implements SoftRowReference<T>
     @Override
     public ContentProviderOperation.Builder assertOperationBuilder(@NonNull TransactionContext transactionContext)
     {
-        return mTable.assertOperation(EmptyUriParams.INSTANCE, new EqArg(BaseColumns._ID, rowId())).contentOperationBuilder(transactionContext);
+        return mTable.assertOperation(EmptyUriParams.INSTANCE, new EqArg<>(BaseColumns._ID, rowId())).contentOperationBuilder(transactionContext);
     }
 
 
@@ -83,9 +83,9 @@ public final class AbsoluteRowReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
+    public Predicate<T> predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
     {
-        return new EqArg(keyColumn, rowId());
+        return new EqArg<>(keyColumn, rowId());
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/BackReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/BackReference.java
@@ -88,9 +88,9 @@ public final class BackReference<T> implements RowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull TransactionContext transactionContext, @NonNull final String keyColumn)
+    public Predicate<T> predicate(@NonNull TransactionContext transactionContext, @NonNull final String keyColumn)
     {
-        return new BackReferenceSelectionPredicate(keyColumn, mBackReference);
+        return new BackReferenceSelectionPredicate<>(keyColumn, mBackReference);
     }
 
 
@@ -103,7 +103,7 @@ public final class BackReference<T> implements RowReference<T>
     }
 
 
-    private static class BackReferenceSelectionPredicate implements Predicate
+    private static class BackReferenceSelectionPredicate<Contract> implements Predicate<Contract>
     {
         private final String mKeyColumn;
         private final int mBackReference;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowSnapshotReference.java
@@ -76,7 +76,7 @@ public final class RowSnapshotReference<T> implements RowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
+    public Predicate<T> predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
     {
         return transactionContext.resolved(mRowSnapshot.reference()).predicate(transactionContext, keyColumn);
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/RowUriReference.java
@@ -78,9 +78,9 @@ public final class RowUriReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
+    public Predicate<T> predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
     {
-        return new EqArg(keyColumn, rowId());
+        return new EqArg<>(keyColumn, rowId());
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/references/VirtualRowReference.java
@@ -80,7 +80,7 @@ public final class VirtualRowReference<T> implements SoftRowReference<T>
 
     @NonNull
     @Override
-    public Predicate predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
+    public Predicate<T> predicate(@NonNull TransactionContext transactionContext, @NonNull String keyColumn)
     {
         throw new UnsupportedOperationException("Can't create a predicate which matches a virtual row.");
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/AllRows.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/AllRows.java
@@ -33,7 +33,7 @@ public final class AllRows<T> extends DelegatingRowSet<T>
 {
     public AllRows(@NonNull View<T> view, @NonNull Projection<T> projection)
     {
-        super(new QueryRowSet<>(view, projection, new AnyOf()));
+        super(new QueryRowSet<>(view, projection, new AnyOf<>()));
     }
 
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/rowsets/QueryRowSet.java
@@ -33,7 +33,6 @@ import org.dmfs.android.contentpal.tools.uriparams.EmptyUriParams;
 import org.dmfs.android.contentpal.transactions.contexts.EmptyTransactionContext;
 import org.dmfs.iterators.AbstractBaseIterator;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -52,10 +51,10 @@ public final class QueryRowSet<T> implements RowSet<T>
 {
     private final View<T> mView;
     private final Projection<? super T> mProjection;
-    private final Predicate mPredicate;
+    private final Predicate<? super T> mPredicate;
 
 
-    public QueryRowSet(@NonNull View<T> view, @NonNull Projection<? super T> projection, @NonNull Predicate predicate)
+    public QueryRowSet(@NonNull View<T> view, @NonNull Projection<? super T> projection, @NonNull Predicate<? super T> predicate)
     {
         mView = view;
         mProjection = projection;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/AccountScoped.java
@@ -63,7 +63,7 @@ public final class AccountScoped<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.updateOperation(uriParams, accountScoped(predicate));
     }
@@ -71,7 +71,7 @@ public final class AccountScoped<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.deleteOperation(uriParams, accountScoped(predicate));
     }
@@ -79,7 +79,7 @@ public final class AccountScoped<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.assertOperation(uriParams, accountScoped(predicate));
     }
@@ -93,8 +93,8 @@ public final class AccountScoped<T> implements Table<T>
     }
 
 
-    private Predicate accountScoped(@NonNull Predicate predicate)
+    private Predicate<? super T> accountScoped(@NonNull Predicate<? super T> predicate)
     {
-        return new AllOf(predicate, new AccountEq(mAccount));
+        return new AllOf<>(predicate, new AccountEq<>(mAccount));
     }
 }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/BaseTable.java
@@ -70,7 +70,7 @@ public final class BaseTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return new Constrained<>(new RawUpdate<>(uriParams.withParam(mTableUri.buildUpon()).build()), predicate);
     }
@@ -78,7 +78,7 @@ public final class BaseTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return new Constrained<>(new RawDelete<>(uriParams.withParam(mTableUri.buildUpon()).build()), predicate);
     }
@@ -86,7 +86,7 @@ public final class BaseTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return new Constrained<>(new RawAssert<>(uriParams.withParam(mTableUri.buildUpon()).build()), predicate);
     }
@@ -111,10 +111,10 @@ public final class BaseTable<T> implements Table<T>
     private final static class Constrained<T> implements Operation<T>
     {
         private final Operation<T> mDelegate;
-        private final Predicate mPredicate;
+        private final Predicate<? super T> mPredicate;
 
 
-        public Constrained(@NonNull Operation<T> delegate, @NonNull Predicate predicate)
+        public Constrained(@NonNull Operation<T> delegate, @NonNull Predicate<? super T> predicate)
         {
             mDelegate = delegate;
             mPredicate = predicate;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/DelegatingTable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/DelegatingTable.java
@@ -57,7 +57,7 @@ public abstract class DelegatingTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public final Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public final Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.updateOperation(uriParams, predicate);
     }
@@ -65,7 +65,7 @@ public abstract class DelegatingTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public final Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public final Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.deleteOperation(uriParams, predicate);
     }
@@ -73,7 +73,7 @@ public abstract class DelegatingTable<T> implements Table<T>
 
     @NonNull
     @Override
-    public final Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public final Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.assertOperation(uriParams, predicate);
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tables/Synced.java
@@ -63,7 +63,7 @@ public final class Synced<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> updateOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.updateOperation(new AccountScopedParams(mAccount, new SyncParams(uriParams)), predicate);
     }
@@ -71,7 +71,7 @@ public final class Synced<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> deleteOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.deleteOperation(new AccountScopedParams(mAccount, new SyncParams(uriParams)), predicate);
     }
@@ -79,7 +79,7 @@ public final class Synced<T> implements Table<T>
 
     @NonNull
     @Override
-    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate predicate)
+    public Operation<T> assertOperation(@NonNull UriParams uriParams, @NonNull Predicate<? super T> predicate)
     {
         return mDelegate.assertOperation(new AccountScopedParams(mAccount, new SyncParams(uriParams)), predicate);
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tools/ClosableEmptyIterator.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tools/ClosableEmptyIterator.java
@@ -20,7 +20,6 @@ import org.dmfs.android.contentpal.ClosableIterator;
 import org.dmfs.iterators.AbstractBaseIterator;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tools/FakeClosable.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tools/FakeClosable.java
@@ -18,7 +18,6 @@ package org.dmfs.android.contentpal.tools;
 
 import org.dmfs.android.contentpal.ClosableIterator;
 
-import java.io.IOException;
 import java.util.Iterator;
 
 import androidx.annotation.NonNull;

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/tools/RowCount.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/tools/RowCount.java
@@ -40,10 +40,10 @@ import static org.dmfs.jems.optional.elementary.Absent.absent;
 public final class RowCount<T> implements Single<Integer>
 {
     private final View<T> mView;
-    private final Predicate mPredicate;
+    private final Predicate<? super T> mPredicate;
 
 
-    public RowCount(@NonNull View<T> view, @NonNull Predicate predicate)
+    public RowCount(@NonNull View<T> view, @NonNull Predicate<? super T> predicate)
     {
         mView = view;
         mPredicate = predicate;
@@ -52,7 +52,7 @@ public final class RowCount<T> implements Single<Integer>
 
     public RowCount(@NonNull View<T> view)
     {
-        this(view, new AnyOf());
+        this(view, new AnyOf<>());
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/AccountScoped.java
@@ -55,9 +55,9 @@ public final class AccountScoped<T> implements View<T>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate<? super T> predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
-        return mDelegate.rows(uriParams, projection, new AllOf(predicate, new AccountEq(mAccount)), sorting);
+        return mDelegate.rows(uriParams, projection, new AllOf<>(predicate, new AccountEq<>(mAccount)), sorting);
     }
 
 

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/BaseView.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/BaseView.java
@@ -61,7 +61,7 @@ public final class BaseView<T> implements View<T>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull final Predicate predicate, @NonNull final Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull final Predicate<? super T> predicate, @NonNull final Optional<String> sorting) throws RemoteException
     {
         List<String> args = new LinkedList<>();
         for (Predicate.Argument arg : predicate.arguments(EmptyTransactionContext.INSTANCE))

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/DelegatingView.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/DelegatingView.java
@@ -50,7 +50,7 @@ public abstract class DelegatingView<T> implements View<T>
 
     @NonNull
     @Override
-    public final Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public final Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate<? super T> predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(uriParams, projection, predicate, sorting);
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/Sorted.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/Sorted.java
@@ -55,7 +55,7 @@ public final class Sorted<T> implements View<T>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate<? super T> predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(uriParams, projection, predicate, new SinglePresent<>(new Backed<>(sorting, mSorting)));
     }

--- a/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
+++ b/contentpal/src/main/java/org/dmfs/android/contentpal/views/Synced.java
@@ -56,7 +56,7 @@ public final class Synced<T> implements View<T>
 
     @NonNull
     @Override
-    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate predicate, @NonNull Optional<String> sorting) throws RemoteException
+    public Cursor rows(@NonNull UriParams uriParams, @NonNull Projection<? super T> projection, @NonNull Predicate<? super T> predicate, @NonNull Optional<String> sorting) throws RemoteException
     {
         return mDelegate.rows(new AccountScopedParams(mAccount, new SyncParams(uriParams)), projection, predicate, sorting);
     }

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MultiInsertBatchTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/batches/MultiInsertBatchTest.java
@@ -20,7 +20,6 @@ import android.content.ContentProviderOperation;
 import android.net.Uri;
 
 import org.dmfs.android.contentpal.InsertOperation;
-import org.dmfs.android.contentpal.RowData;
 import org.dmfs.android.contentpal.TransactionContext;
 import org.dmfs.android.contentpal.rowdata.CharSequenceRowData;
 import org.dmfs.android.contentpal.rowdata.Composite;
@@ -29,7 +28,6 @@ import org.dmfs.jems.optional.elementary.Absent;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkAssertTest.java
@@ -97,7 +97,7 @@ public final class BulkAssertTest
     public void testContentOperationBuilder_ctor_table_predicate()
     {
         Table<Object> mockTable = failingMock(Table.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Operation<Object> mockAssertOperation = failingMock(Operation.class);
 
         doReturn(mockAssertOperation).when(mockTable).assertOperation(EmptyUriParams.INSTANCE, dummyPredicate);
@@ -139,7 +139,7 @@ public final class BulkAssertTest
     public void testContentOperationBuilder_ctor_table_data_predicate()
     {
         Table<Object> mockTable = failingMock(Table.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Operation<Object> mockAssertOperation = failingMock(Operation.class);
 
         doReturn(mockAssertOperation).when(mockTable).assertOperation(EmptyUriParams.INSTANCE, dummyPredicate);

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkDeleteTest.java
@@ -91,7 +91,7 @@ public final class BulkDeleteTest
     {
         Table<Object> mockTable = failingMock(Table.class);
         Operation<Object> mockOperation = failingMock(Operation.class);
-        Predicate dummyPredicate = mock(Predicate.class);
+        Predicate<Object> dummyPredicate = mock(Predicate.class);
 
         doReturn(mockOperation).when(mockTable).deleteOperation(EmptyUriParams.INSTANCE, dummyPredicate);
         Uri dummyUri = dummy(Uri.class);

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/operations/BulkUpdateTest.java
@@ -97,7 +97,7 @@ public final class BulkUpdateTest
     public void testContentOperationBuilder_ctor_table_data_predicate()
     {
         Table<Object> mockTable = failingMock(Table.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Operation<Object> mockOperation = failingMock(Operation.class);
 
         doReturn(mockOperation).when(mockTable).updateOperation(EmptyUriParams.INSTANCE, dummyPredicate);

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AccountEqTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AccountEqTest.java
@@ -43,7 +43,7 @@ public final class AccountEqTest
     @Test
     public void test()
     {
-        assertThat(new AccountEq(new Account("name", "type")),
+        assertThat(new AccountEq<>(new Account("name", "type")),
                 predicateWith(
                         selection("( account_name = ? ) and ( account_type = ? )"),
                         argumentValues("name", "type"),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AllOfTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AllOfTest.java
@@ -38,21 +38,21 @@ public class AllOfTest
     @Test
     public void test()
     {
-        assertThat(new AllOf(), predicateWith(
+        assertThat(new AllOf<>(), predicateWith(
                 selection("1"),
                 emptyArguments()));
 
-        assertThat(new AllOf(new Mocked("x", "a")), predicateWith(
+        assertThat(new AllOf<>(new Mocked<>("x", "a")), predicateWith(
                 selection("( x )"),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new AllOf(new Mocked("x", "a"), new Mocked("y", "1")), predicateWith(
+        assertThat(new AllOf<>(new Mocked<>("x", "a"), new Mocked<>("y", "1")), predicateWith(
                 selection("( x ) and ( y )"),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new AllOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")), predicateWith(
+        assertThat(new AllOf<>(new Mocked<>("x", "a"), new Mocked<>("z", "w", "z"), new Mocked<>("y", "1")), predicateWith(
                 selection("( x ) and ( z ) and ( y )"),
                 argumentValues("a", "w", "z", "1"),
                 absentBackReferences(4)));
@@ -62,21 +62,21 @@ public class AllOfTest
     @Test
     public void testIterable()
     {
-        assertThat(new AllOf(EmptyIterable.instance()), predicateWith(
+        assertThat(new AllOf<>(EmptyIterable.instance()), predicateWith(
                 selection("1"),
                 emptyArguments()));
 
-        assertThat(new AllOf(new Seq<>(new Mocked("x", "a"))), predicateWith(
+        assertThat(new AllOf<>(new Seq<>(new Mocked<>("x", "a"))), predicateWith(
                 selection("( x )"),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new AllOf(new Seq<>(new Mocked("x", "a"), new Mocked("y", "1"))), predicateWith(
+        assertThat(new AllOf<>(new Seq<>(new Mocked<>("x", "a"), new Mocked<>("y", "1"))), predicateWith(
                 selection("( x ) and ( y )"),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new AllOf(new Seq<>(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1"))), predicateWith(
+        assertThat(new AllOf<>(new Seq<>(new Mocked<>("x", "a"), new Mocked<>("z", "w", "z"), new Mocked<>("y", "1"))), predicateWith(
                 selection("( x ) and ( z ) and ( y )"),
                 argumentValues("a", "w", "z", "1"),
                 absentBackReferences(4)));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AnyOfTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/AnyOfTest.java
@@ -38,21 +38,21 @@ public class AnyOfTest
     @Test
     public void test()
     {
-        assertThat(new AnyOf(), predicateWith(
+        assertThat(new AnyOf<>(), predicateWith(
                 selection("1"),
                 emptyArguments()));
 
-        assertThat(new AnyOf(new Mocked("x", "a")), predicateWith(
+        assertThat(new AnyOf<>(new Mocked<>("x", "a")), predicateWith(
                 selection("( x )"),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new AnyOf(new Mocked("x", "a"), new Mocked("y", "1")), predicateWith(
+        assertThat(new AnyOf<>(new Mocked<>("x", "a"), new Mocked<>("y", "1")), predicateWith(
                 selection("( x ) or ( y )"),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new AnyOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")), predicateWith(
+        assertThat(new AnyOf<>(new Mocked<>("x", "a"), new Mocked<>("z", "w", "z"), new Mocked<>("y", "1")), predicateWith(
                 selection("( x ) or ( z ) or ( y )"),
                 argumentValues("a", "w", "z", "1"),
                 absentBackReferences(4)));
@@ -62,21 +62,21 @@ public class AnyOfTest
     @Test
     public void testIterable()
     {
-        assertThat(new AnyOf(EmptyIterable.instance()), predicateWith(
+        assertThat(new AnyOf<>(EmptyIterable.instance()), predicateWith(
                 selection("1"),
                 emptyArguments()));
 
-        assertThat(new AnyOf(new Seq<>(new Mocked("x", "a"))), predicateWith(
+        assertThat(new AnyOf<>(new Seq<>(new Mocked<>("x", "a"))), predicateWith(
                 selection("( x )"),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new AnyOf(new Seq<>(new Mocked("x", "a"), new Mocked("y", "1"))), predicateWith(
+        assertThat(new AnyOf<>(new Seq<>(new Mocked<>("x", "a"), new Mocked<>("y", "1"))), predicateWith(
                 selection("( x ) or ( y )"),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new AnyOf(new Seq<>(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1"))), predicateWith(
+        assertThat(new AnyOf<>(new Seq<>(new Mocked<>("x", "a"), new Mocked<>("z", "w", "z"), new Mocked<>("y", "1"))), predicateWith(
                 selection("( x ) or ( z ) or ( y )"),
                 argumentValues("a", "w", "z", "1"),
                 absentBackReferences(4)));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqArgTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqArgTest.java
@@ -34,7 +34,7 @@ public class EqArgTest
     @Test
     public void test()
     {
-        assertThat(new EqArg("x", "y"),
+        assertThat(new EqArg<>("x", "y"),
                 predicateWith(
                         selection("x = ?"),
                         argumentValues("y"),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqColTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/EqColTest.java
@@ -33,7 +33,7 @@ public class EqColTest
     @Test
     public void test()
     {
-        assertThat(new EqCol("x", "y"),
+        assertThat(new EqCol<>("x", "y"),
                 predicateWith(
                         selection("x = y"),
                         emptyArguments()

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/IdInTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/IdInTest.java
@@ -39,7 +39,7 @@ public class IdInTest
     @Test
     public void testLong()
     {
-        assertThat(new IdIn(123), predicateWith(
+        assertThat(new IdIn<>(123), predicateWith(
                 selection("_id = ?"),
                 argumentValues("123"),
                 absentBackReferences(1)
@@ -50,7 +50,7 @@ public class IdInTest
     @Test
     public void testLongVarArg()
     {
-        assertThat(new IdIn(1L, 2L, 3L), predicateWith(
+        assertThat(new IdIn<>(1L, 2L, 3L), predicateWith(
                 selection("_id in ( ?, ?, ? ) "),
                 argumentValues("1", "2", "3"),
                 absentBackReferences(3)
@@ -61,7 +61,7 @@ public class IdInTest
     @Test
     public void testEmptyLongVarArg()
     {
-        assertThat(new IdIn(new Long[0]), predicateWith(
+        assertThat(new IdIn<>(new Long[0]), predicateWith(
                 selection("_id in (  ) "),
                 emptyArguments()
         ));
@@ -71,7 +71,7 @@ public class IdInTest
     @Test
     public void testString()
     {
-        assertThat(new IdIn("123"), predicateWith(
+        assertThat(new IdIn<>("123"), predicateWith(
                 selection("_id = ?"),
                 argumentValues("123"),
                 absentBackReferences(1)
@@ -82,7 +82,7 @@ public class IdInTest
     @Test
     public void testStringVarArg()
     {
-        assertThat(new IdIn("1", "2", "3"), predicateWith(
+        assertThat(new IdIn<>("1", "2", "3"), predicateWith(
                 selection("_id in ( ?, ?, ? ) "),
                 argumentValues("1", "2", "3"),
                 absentBackReferences(3)
@@ -93,7 +93,7 @@ public class IdInTest
     @Test
     public void testEmptyStringVarArg()
     {
-        assertThat(new IdIn(new String[0]), predicateWith(
+        assertThat(new IdIn<>(new String[0]), predicateWith(
                 selection("_id in (  ) "),
                 emptyArguments()
         ));
@@ -103,7 +103,7 @@ public class IdInTest
     @Test
     public void testLongIterable()
     {
-        assertThat(new IdIn(new Seq<>(1L, 2L, 3L)), predicateWith(
+        assertThat(new IdIn<>(new Seq<>(1L, 2L, 3L)), predicateWith(
                 selection("_id in ( ?, ?, ? ) "),
                 argumentValues("1", "2", "3"),
                 absentBackReferences(3)
@@ -114,7 +114,7 @@ public class IdInTest
     @Test
     public void testEmptyLongIterable()
     {
-        assertThat(new IdIn(EmptyIterable.instance()), predicateWith(
+        assertThat(new IdIn<>(EmptyIterable.instance()), predicateWith(
                 selection("_id in (  ) "),
                 emptyArguments()
         ));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/InTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/InTest.java
@@ -50,21 +50,21 @@ public class InTest
     @Test
     public void test()
     {
-        assertThat(new In("x"), predicateWith(
+        assertThat(new In<>("x"), predicateWith(
                 selection("x in (  ) "),
                 emptyArguments()));
 
-        assertThat(new In("x", "a"), predicateWith(
+        assertThat(new In<>("x", "a"), predicateWith(
                 selection("x in ( ? ) "),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new In("x", "a", 1), predicateWith(
+        assertThat(new In<>("x", "a", 1), predicateWith(
                 selection("x in ( ?, ? ) "),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new In("x", "a", 1, 1.2), predicateWith(
+        assertThat(new In<>("x", "a", 1, 1.2), predicateWith(
                 selection("x in ( ?, ?, ? ) "),
                 argumentValues("a", "1", "1.2"),
                 absentBackReferences(3)));
@@ -74,21 +74,21 @@ public class InTest
     @Test
     public void testIterable()
     {
-        assertThat(new In("x", EmptyIterable.instance()), predicateWith(
+        assertThat(new In<>("x", EmptyIterable.instance()), predicateWith(
                 selection("x in (  ) "),
                 emptyArguments()));
 
-        assertThat(new In("x", new Seq<>("a")), predicateWith(
+        assertThat(new In<>("x", new Seq<>("a")), predicateWith(
                 selection("x in ( ? ) "),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new In("x", new Seq<>("a", 1)), predicateWith(
+        assertThat(new In<>("x", new Seq<>("a", 1)), predicateWith(
                 selection("x in ( ?, ? ) "),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new In("x", new Seq<>("a", 1, 1.2)), predicateWith(
+        assertThat(new In<>("x", new Seq<>("a", 1, 1.2)), predicateWith(
                 selection("x in ( ?, ?, ? ) "),
                 argumentValues("a", "1", "1.2"),
                 absentBackReferences(3)));
@@ -102,7 +102,7 @@ public class InTest
 
         doReturn(new FakeClosable<>(emptyIterator())).when(mockRowSet).iterator();
 
-        assertThat(new In("x", mockRowSet), predicateWith(
+        assertThat(new In<>("x", mockRowSet), predicateWith(
                 selection("x in (  ) "),
                 emptyArguments()));
 
@@ -112,7 +112,7 @@ public class InTest
         doReturn(new MapRowDataSnapshot<>(valueMap1, new HashMap<>())).when(rowSnapshot1).values();
         doAnswer(invocation -> new FakeClosable<>(new org.dmfs.iterators.elementary.Seq<>(rowSnapshot1))).when(mockRowSet).iterator();
 
-        assertThat(new In("x", mockRowSet), predicateWith(
+        assertThat(new In<>("x", mockRowSet), predicateWith(
                 selection("x in ( ? ) "),
                 argumentValues("1"),
                 absentBackReferences(1)));
@@ -123,7 +123,7 @@ public class InTest
         doReturn(new MapRowDataSnapshot<>(valueMap2, new HashMap<>())).when(rowSnapshot2).values();
         doAnswer(invocation -> new FakeClosable<>(new org.dmfs.iterators.elementary.Seq<>(rowSnapshot1, rowSnapshot2))).when(mockRowSet).iterator();
 
-        assertThat(new In("x", mockRowSet), predicateWith(
+        assertThat(new In<>("x", mockRowSet), predicateWith(
                 selection("x in ( ?, ? ) "),
                 argumentValues("1", "2"),
                 absentBackReferences(2)));
@@ -135,7 +135,7 @@ public class InTest
         doAnswer(invocation -> new FakeClosable<>(new org.dmfs.iterators.elementary.Seq<>(rowSnapshot1, rowSnapshot2, rowSnapshot3))).when(mockRowSet)
                 .iterator();
 
-        assertThat(new In("x", mockRowSet), predicateWith(
+        assertThat(new In<>("x", mockRowSet), predicateWith(
                 selection("x in ( ?, ?, ? ) "),
                 argumentValues("1", "2", "3"),
                 absentBackReferences(3)));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/IsNullTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/IsNullTest.java
@@ -33,7 +33,7 @@ public class IsNullTest
     @Test
     public void test()
     {
-        assertThat(new IsNull("x"),
+        assertThat(new IsNull<>("x"),
                 predicateWith(
                         selection("x is null"),
                         emptyArguments()

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/LikeArgTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/LikeArgTest.java
@@ -34,7 +34,7 @@ public class LikeArgTest
     @Test
     public void test()
     {
-        assertThat(new LikeArg("x", "y"),
+        assertThat(new LikeArg<>("x", "y"),
                 predicateWith(
                         selection("x like ?"),
                         argumentValues("y"),

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NoneOfTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NoneOfTest.java
@@ -38,21 +38,21 @@ public class NoneOfTest
     @Test
     public void test()
     {
-        assertThat(new NoneOf(), predicateWith(
+        assertThat(new NoneOf<>(), predicateWith(
                 selection("not ( 1 )"),
                 emptyArguments()));
 
-        assertThat(new NoneOf(new Mocked("x", "a")), predicateWith(
+        assertThat(new NoneOf<>(new Mocked<>("x", "a")), predicateWith(
                 selection("not ( ( x ) )"),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new NoneOf(new Mocked("x", "a"), new Mocked("y", "1")), predicateWith(
+        assertThat(new NoneOf<>(new Mocked<>("x", "a"), new Mocked<>("y", "1")), predicateWith(
                 selection("not ( ( x ) or ( y ) )"),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new NoneOf(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1")), predicateWith(
+        assertThat(new NoneOf<>(new Mocked<>("x", "a"), new Mocked<>("z", "w", "z"), new Mocked<>("y", "1")), predicateWith(
                 selection("not ( ( x ) or ( z ) or ( y ) )"),
                 argumentValues("a", "w", "z", "1"),
                 absentBackReferences(4)));
@@ -62,21 +62,21 @@ public class NoneOfTest
     @Test
     public void testIterable()
     {
-        assertThat(new NoneOf(EmptyIterable.instance()), predicateWith(
+        assertThat(new NoneOf<>(EmptyIterable.instance()), predicateWith(
                 selection("not ( 1 )"),
                 emptyArguments()));
 
-        assertThat(new NoneOf(new Seq<>(new Mocked("x", "a"))), predicateWith(
+        assertThat(new NoneOf<>(new Seq<>(new Mocked<>("x", "a"))), predicateWith(
                 selection("not ( ( x ) )"),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new NoneOf(new Seq<>(new Mocked("x", "a"), new Mocked("y", "1"))), predicateWith(
+        assertThat(new NoneOf<>(new Seq<>(new Mocked<>("x", "a"), new Mocked<>("y", "1"))), predicateWith(
                 selection("not ( ( x ) or ( y ) )"),
                 argumentValues("a", "1"),
                 absentBackReferences(2)));
 
-        assertThat(new NoneOf(new Seq<>(new Mocked("x", "a"), new Mocked("z", "w", "z"), new Mocked("y", "1"))), predicateWith(
+        assertThat(new NoneOf<>(new Seq<>(new Mocked<>("x", "a"), new Mocked<>("z", "w", "z"), new Mocked<>("y", "1"))), predicateWith(
                 selection("not ( ( x ) or ( z ) or ( y ) )"),
                 argumentValues("a", "w", "z", "1"),
                 absentBackReferences(4)));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotNullTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotNullTest.java
@@ -33,7 +33,7 @@ public class NotNullTest
     @Test
     public void test()
     {
-        assertThat(new NotNull("x"),
+        assertThat(new NotNull<>("x"),
                 predicateWith(
                         selection("x is not null"),
                         emptyArguments()

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/predicates/NotTest.java
@@ -35,12 +35,12 @@ public class NotTest
     @Test
     public void test()
     {
-        assertThat(new Not(new Mocked("x", "a")), predicateWith(
+        assertThat(new Not<>(new Mocked<>("x", "a")), predicateWith(
                 selection("not ( x )"),
                 argumentValues("a"),
                 absentBackReferences(1)));
 
-        assertThat(new Not(new Mocked("x", "a", "z", "w")), predicateWith(
+        assertThat(new Not<>(new Mocked<>("x", "a", "z", "w")), predicateWith(
                 selection("not ( x )"),
                 argumentValues("a", "z", "w"),
                 absentBackReferences(3)));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/references/RowSnapshotReferenceTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/references/RowSnapshotReferenceTest.java
@@ -116,7 +116,7 @@ public class RowSnapshotReferenceTest
     @Test
     public void testPredicate()
     {
-        Predicate dummyResultPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyResultPredicate = dummy(Predicate.class);
         SoftRowReference<Object> dummyOriginalReference = dummy(SoftRowReference.class);
         RowReference<Object> mockResolvedReference = failingMock(RowReference.class);
         RowSnapshot<Object> mockSnapshot = failingMock(RowSnapshot.class);

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/tables/SyncedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/tables/SyncedTest.java
@@ -64,7 +64,7 @@ public class SyncedTest
     public void testUpdateOperation()
     {
         Operation<Object> dummyResultOperation = dummy(Operation.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Table<Object> mockTable = failingMock(Table.class);
         Account account = new Account("name", "type");
         doReturn(dummyResultOperation).when(mockTable).updateOperation(argThat(new UriParamsArgumentMatcher(account)), same(dummyPredicate));
@@ -78,7 +78,7 @@ public class SyncedTest
     public void testDeleteOperation()
     {
         Operation<Object> dummyResultOperation = dummy(Operation.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Table<Object> mockTable = failingMock(Table.class);
         Account account = new Account("name", "type");
         doReturn(dummyResultOperation).when(mockTable).deleteOperation(argThat(new UriParamsArgumentMatcher(account)), same(dummyPredicate));
@@ -92,7 +92,7 @@ public class SyncedTest
     public void testAssertOperation()
     {
         Operation<Object> dummyResultOperation = dummy(Operation.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Table<Object> mockTable = failingMock(Table.class);
         Account account = new Account("name", "type");
         doReturn(dummyResultOperation).when(mockTable).assertOperation(argThat(new UriParamsArgumentMatcher(account)), same(dummyPredicate));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/tools/RowCountTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/tools/RowCountTest.java
@@ -56,7 +56,7 @@ public final class RowCountTest
     public void test_thatCursorGetCountIsReturned() throws Exception
     {
         View<Object> mockView = failingMock(View.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Cursor mockCursor = failingMock(Cursor.class);
 
         doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(absent()));
@@ -89,7 +89,7 @@ public final class RowCountTest
     public void test_whenRowsThrows_ExceptionIsThrown() throws Exception
     {
         View<Object> mockView = failingMock(View.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
 
         doThrow(new RemoteException("msg")).when(mockView)
                 .rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(absent()));
@@ -102,7 +102,7 @@ public final class RowCountTest
     public void test_whenCursorGetCountThrows_CursorIsClosed() throws Exception
     {
         View<Object> mockView = mock(View.class, new FailAnswer());
-        Predicate dummyPredicate = mock(Predicate.class, new FailAnswer());
+        Predicate<Object> dummyPredicate = mock(Predicate.class, new FailAnswer());
         Cursor mockCursor = mock(Cursor.class, new FailAnswer());
 
         doReturn(mockCursor).when(mockView).rows(same(EmptyUriParams.INSTANCE), any(Projection.class), same(dummyPredicate), same(absent()));

--- a/contentpal/src/test/java/org/dmfs/android/contentpal/views/SyncedTest.java
+++ b/contentpal/src/test/java/org/dmfs/android/contentpal/views/SyncedTest.java
@@ -58,7 +58,7 @@ public class SyncedTest
     public void test() throws RemoteException
     {
         Cursor dummyResult = dummy(Cursor.class);
-        Predicate dummyPredicate = dummy(Predicate.class);
+        Predicate<Object> dummyPredicate = dummy(Predicate.class);
         Projection<Object> dummyProjection = dummy(Projection.class);
         View<Object> mockView = failingMock(View.class);
         Account account = new Account("name", "type");

--- a/contenttestpal/src/main/java/org/dmfs/android/contenttestpal/operations/AssertRelated.java
+++ b/contenttestpal/src/main/java/org/dmfs/android/contenttestpal/operations/AssertRelated.java
@@ -41,19 +41,19 @@ import androidx.annotation.NonNull;
 public final class AssertRelated<T> extends DelegatingOperation<T>
 {
 
-    public AssertRelated(@NonNull Table<T> table, @NonNull String foreignKeyColumn, RowSnapshot<?> rowSnapshot, @NonNull RowData<T> rowData, @NonNull Predicate predicate)
+    public AssertRelated(@NonNull Table<T> table, @NonNull String foreignKeyColumn, RowSnapshot<?> rowSnapshot, @NonNull RowData<T> rowData, @NonNull Predicate<? super T> predicate)
     {
-        super(new Counted<>(1, new BulkAssert<>(table, rowData, new AllOf(predicate, new ReferringTo<>(foreignKeyColumn, rowSnapshot)))));
+        super(new Counted<>(1, new BulkAssert<>(table, rowData, new AllOf<>(predicate, new ReferringTo<>(foreignKeyColumn, rowSnapshot)))));
     }
 
 
     public AssertRelated(@NonNull Table<T> table, @NonNull String foreignKeyColumn, @NonNull RowSnapshot<?> rowSnapshot, @NonNull RowData<T> rowData)
     {
-        this(table, foreignKeyColumn, rowSnapshot, rowData, new AnyOf());
+        this(table, foreignKeyColumn, rowSnapshot, rowData, new AnyOf<>());
     }
 
 
-    public AssertRelated(@NonNull Table<T> table, @NonNull String foreignKeyColumn, @NonNull RowSnapshot<?> rowSnapshot, @NonNull Predicate predicate)
+    public AssertRelated(@NonNull Table<T> table, @NonNull String foreignKeyColumn, @NonNull RowSnapshot<?> rowSnapshot, @NonNull Predicate<? super T> predicate)
     {
         this(table, foreignKeyColumn, rowSnapshot, EmptyRowData.instance(), predicate);
     }
@@ -61,6 +61,6 @@ public final class AssertRelated<T> extends DelegatingOperation<T>
 
     public AssertRelated(@NonNull Table<T> table, @NonNull String foreignKeyColumn, @NonNull RowSnapshot<?> rowSnapshot)
     {
-        this(table, foreignKeyColumn, rowSnapshot, EmptyRowData.instance(), new AnyOf());
+        this(table, foreignKeyColumn, rowSnapshot, EmptyRowData.instance(), new AnyOf<>());
     }
 }


### PR DESCRIPTION
This adds a generic parameter to Predicate. A Predicate is now bound to a specific contract and can not be used on another table.