### PR TITLE
Add dist entry to .travis.yml, fixes #210

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+dist: trusty
 android:
   components:
     - tools


### PR DESCRIPTION
According to https://travis-ci.community/t/installing-android-dependencies-android-update-sdk-command-not-found/4138 this is the easiest way to fix the issue of failing builds.